### PR TITLE
_is_zipfile Fix

### DIFF
--- a/modelscan/tools/utils.py
+++ b/modelscan/tools/utils.py
@@ -60,8 +60,10 @@ def _is_zipfile(source: Union[Path, str], data: Optional[IO[bytes]] = None) -> b
     # collisions and assume the zip has only 1 file.
     # See bugs.python.org/issue28494.
     if not data:
-        with open(source, "rb") as f:
-            data = f
+        data = open(source, "rb")
+        file = True
+    else:
+        file = False
 
     # Read the first 4 bytes of the file
     read_bytes = []
@@ -74,6 +76,8 @@ def _is_zipfile(source: Union[Path, str], data: Optional[IO[bytes]] = None) -> b
             break
         byte = data.read(1)
     data.seek(start)
+    if file:
+        data.close()
 
     local_header_magic_number = [b"P", b"K", b"\x03", b"\x04"]
     return read_bytes == local_header_magic_number


### PR DESCRIPTION
_is_zipfile was throwing a "ValueError: I/O operation on closed file" for cases from files because the file was being closed