### PR TITLE
Add version flag to cli options

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,12 +110,12 @@ modelscan = ">=0.1.1"
 
 ModelScan supports the following arguments via the CLI:
 
-| Usage                                 | Argument                                         | Explanation 
-|---------------------------------------|--------------------------------------------------| ----|
-| ```modelscan -h ```                   | -h or --help                                        | View Help
-| ```modelscan -p /path/to/model_file``` | -p or --path                                  | Scan a locally stored model
-| ```modelscan -hf repo/model_file```   |-hf or --huggingface  | Scan all the models in a Hugging Face model repository
-
+| Usage                                 | Argument             | Explanation                                | 
+|---------------------------------------|----------------------| -------------------------------------------|
+| ```modelscan -h ```                   | -h or --help         | View usage help                            |
+| ```modelscan -v ```                   | -v or --version      | View version information                   |
+| ```modelscan -p /path/to/model_file```| -p or --path         | Scan a locally stored model                |
+| ```modelscan -hf repo/model_file```   |-hf or --huggingface  | Scan all the models in a Hugging Face model repository| 
 
 Remember models are just like any other form of digital media, you should scan content from any untrusted source before use.
 

--- a/modelscan/cli.py
+++ b/modelscan/cli.py
@@ -7,6 +7,7 @@ import click
 
 from modelscan.modelscan import Modelscan
 from modelscan.reports import ConsoleReport
+from modelscan._version import __version__
 
 logger = logging.getLogger("modelscan")
 
@@ -18,6 +19,7 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
     context_settings=CONTEXT_SETTINGS,
     help="Modelscan detects machine learning model files that perform suspicious actions",
 )
+@click.version_option(__version__, "-v", "--version")
 @click.option(
     "-p",
     "--path",


### PR DESCRIPTION
- Update click options to add version flag. Both -v and --version option should work.
- Update README to include the version option. 