### PR TITLE
Add .keras scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ At present, ModelScan supports any Pickle derived format and many others:
 | Pytorch | [torch.save() and torch.load()](https://pytorch.org/tutorials/beginner/saving_loading_models.html )| Pickle                              | Yes 
 | Tensorflow| [tf.saved_model.save()](https://www.tensorflow.org/guide/saved_model)| Protocol Buffer                     | Yes 
 | Keras| [keras.models.save(save_format= 'h5')](https://www.tensorflow.org/guide/keras/serialization_and_saving)| HD5 (Hierarchical Data Format)      | Yes 
-| | [keras.models.save(save_format= 'keras')](https://www.tensorflow.org/guide/keras/serialization_and_saving)| Keras V3 (Hierarchical Data Format) | No
+| | [keras.models.save(save_format= 'keras')](https://www.tensorflow.org/guide/keras/serialization_and_saving)| Keras V3 (Hierarchical Data Format) | Yes
 | Classic ML Libraries (Sklearn, XGBoost etc.)| pickle.dump(), dill.dump(), joblib.dump(), cloudpickle.dump() | Pickle, Cloudpickle, Dill, Joblib   | Yes 
 
 

--- a/modelscan/models/__init__.py
+++ b/modelscan/models/__init__.py
@@ -5,3 +5,4 @@ from modelscan.models.pickle.scan import (
     PyTorchScan,
 )
 from modelscan.models.saved_model.scan import SavedModelScan
+from modelscan.models.keras.scan import KerasScan

--- a/modelscan/models/keras/scan.py
+++ b/modelscan/models/keras/scan.py
@@ -1,0 +1,72 @@
+import json
+import zipfile
+import logging
+from pathlib import Path
+from typing import IO, List, Tuple, Union, Optional
+
+from modelscan.error import Error, ModelScanError
+from modelscan.issues import Issue
+from modelscan.models.saved_model.scan import SavedModelScan
+
+logger = logging.getLogger("modelscan")
+
+
+class KerasScan(SavedModelScan):
+    @staticmethod
+    def scan(
+        source: Union[str, Path],
+        data: Optional[IO[bytes]] = None,
+    ) -> Tuple[List[Issue], List[Error]]:
+        if data:
+            logger.warning(
+                "Keras scanner got data bytes. It only support direct file scanning."
+            )
+
+        with zipfile.ZipFile(data or source, "r") as zip:
+            file_names = zip.namelist()
+            for file_name in file_names:
+                if file_name == "config.json":
+                    with zip.open(file_name, "r") as config_file:
+                        return KerasScan._scan_keras_config_file(
+                            source=f"{source}:{file_name}", config_file=config_file
+                        )
+        # Added return to pass the failing mypy test: Missing return statement
+        return [], [
+            ModelScanError(
+                SavedModelScan.name(),
+                f"Unable to scan .keras file",  # Not sure if this is a representative message for ModelScanError
+            )
+        ]
+
+    @staticmethod
+    def _scan_keras_config_file(
+        source: Union[str, Path], config_file: IO[bytes]
+    ) -> Tuple[List[Issue], List[Error]]:
+        machine_learning_library_name = "Keras"
+        operators_in_model = KerasScan._get_keras_operator_names(config_file)
+        return KerasScan._check_for_unsafe_tf_keras_operator(
+            module_name=machine_learning_library_name,
+            raw_operator=operators_in_model,
+            source=source,
+        )
+
+    @staticmethod
+    def _get_keras_operator_names(data: IO[bytes]) -> List[str]:
+        # Todo: source isn't guaranteed to be a file
+
+        model_config_data = json.load(data)
+        lambda_code = [
+            layer.get("config", {}).get("function", {})
+            for layer in model_config_data["config"]["layers"]
+            if layer["class_name"] == "Lambda"
+        ]
+
+        return ["Lambda"] if lambda_code else []
+
+    @staticmethod
+    def supported_extensions() -> List[str]:
+        return [".keras"]
+
+    @staticmethod
+    def name() -> str:
+        return ".keras"

--- a/modelscan/models/keras/scan.py
+++ b/modelscan/models/keras/scan.py
@@ -17,19 +17,23 @@ class KerasScan(SavedModelScan):
         source: Union[str, Path],
         data: Optional[IO[bytes]] = None,
     ) -> Tuple[List[Issue], List[Error]]:
-        if data:
-            logger.warning(
-                "Keras scanner got data bytes. It only support direct file scanning."
-            )
+        try:
+            with zipfile.ZipFile(data or source, "r") as zip:
+                file_names = zip.namelist()
+                for file_name in file_names:
+                    if file_name == "config.json":
+                        with zip.open(file_name, "r") as config_file:
+                            return KerasScan._scan_keras_config_file(
+                                source=f"{source}:{file_name}", config_file=config_file
+                            )
+        except zipfile.BadZipFile as e:
+            return [], [
+                ModelScanError(
+                    KerasScan.name(),
+                    f"Skipping zip file {source}, due to error: {e}",
+                )
+            ]
 
-        with zipfile.ZipFile(data or source, "r") as zip:
-            file_names = zip.namelist()
-            for file_name in file_names:
-                if file_name == "config.json":
-                    with zip.open(file_name, "r") as config_file:
-                        return KerasScan._scan_keras_config_file(
-                            source=f"{source}:{file_name}", config_file=config_file
-                        )
         # Added return to pass the failing mypy test: Missing return statement
         return [], [
             ModelScanError(
@@ -43,7 +47,7 @@ class KerasScan(SavedModelScan):
         source: Union[str, Path], config_file: IO[bytes]
     ) -> Tuple[List[Issue], List[Error]]:
         machine_learning_library_name = "Keras"
-        operators_in_model = KerasScan._get_keras_operator_names(config_file)
+        operators_in_model = KerasScan._get_keras_operator_names(source, config_file)
         return KerasScan._check_for_unsafe_tf_keras_operator(
             module_name=machine_learning_library_name,
             raw_operator=operators_in_model,
@@ -51,15 +55,19 @@ class KerasScan(SavedModelScan):
         )
 
     @staticmethod
-    def _get_keras_operator_names(data: IO[bytes]) -> List[str]:
-        # Todo: source isn't guaranteed to be a file
-
-        model_config_data = json.load(data)
-        lambda_code = [
-            layer.get("config", {}).get("function", {})
-            for layer in model_config_data["config"]["layers"]
-            if layer["class_name"] == "Lambda"
-        ]
+    def _get_keras_operator_names(
+        source: Union[str, Path], data: IO[bytes]
+    ) -> List[str]:
+        try:
+            model_config_data = json.load(data)
+            lambda_code = [
+                layer.get("config", {}).get("function", {})
+                for layer in model_config_data["config"]["layers"]
+                if layer["class_name"] == "Lambda"
+            ]
+        except json.JSONDecodeError as e:
+            logger.error(f"Not a valid JSON data from source: {source}, error: {e}")
+            return []
 
         return ["Lambda"] if lambda_code else []
 

--- a/modelscan/models/keras/scan.py
+++ b/modelscan/models/keras/scan.py
@@ -33,7 +33,7 @@ class KerasScan(SavedModelScan):
         # Added return to pass the failing mypy test: Missing return statement
         return [], [
             ModelScanError(
-                SavedModelScan.name(),
+                KerasScan.name(),
                 f"Unable to scan .keras file",  # Not sure if this is a representative message for ModelScanError
             )
         ]

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -11,6 +11,7 @@ from typing import List, Union, Optional, IO
 from modelscan.error import Error
 from modelscan.issues import Issues, Issue
 from modelscan import models
+from modelscan.models.keras.scan import KerasScan
 from modelscan.models.scan import ScanBase
 from modelscan.tools.utils import _http_get, _is_zipfile
 
@@ -44,7 +45,7 @@ class Modelscan:
         if path.is_dir():
             self._scan_directory(path)
         elif _is_zipfile(path) or path.suffix in self._supported_zip_extensions():
-            is_keras_file = True if path.suffix == ".keras" else False
+            is_keras_file = path.suffix in KerasScan.supported_extensions()
             if is_keras_file:
                 self._scan_source(source=path, extension=path.suffix)
             else:

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -28,6 +28,7 @@ class Modelscan:
             and issubclass(member, ScanBase)
             and not inspect.isabstract(member)
         ]
+
         self.supported_extensions = set()
         for scan in self.supported_model_scans:
             self.supported_extensions.update(scan.supported_extensions())
@@ -43,7 +44,11 @@ class Modelscan:
         if path.is_dir():
             self._scan_directory(path)
         elif _is_zipfile(path) or path.suffix in self._supported_zip_extensions():
-            self._scan_zip(path)
+            is_keras_file = True if path.suffix == ".keras" else False
+            if is_keras_file:
+                self._scan_source(source=path, extension=path.suffix)
+            else:
+                self._scan_zip(path)
         else:
             self._scan_source(source=path, extension=path.suffix)
 

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -769,7 +769,7 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
                 OperatorIssueDetails(
                     "Keras",
                     "Lambda",
-                    f"{keras_file_path}/unsafe.keras:config.json",
+                    f"{keras_file_path}/unsafe{file_extension}:config.json",
                 ),
             )
         ]
@@ -790,7 +790,6 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
             )
         ]
         ms.scan_path(Path(f"{keras_file_path}/unsafe{file_extension}"))
-    print(ms.issues.add_issues)
     assert ms.issues.all_issues == expected
 
 


### PR DESCRIPTION
This PR adds `.keras` scan capability to `modelscan`. 

The [.keras serialization format](https://www.tensorflow.org/guide/keras/serialization_and_saving#introduction) saves the model file as a zip file that contains:

- A JSON-based configuration file (`config.json`): Records of model, layer, and other trackables' configuration.
     - `modelscan` will scan the `config.json` to search for lambda layer 

- A H5-based state file, such as `model.weights.h5` (for the whole model), with directory keys for layers and their weights.
- A metadata file in JSON, storing things such as the current Keras version.

Closes #36 