### PR TITLE
Make blocklist use substrings instead of direct equality, other patches.

### DIFF
--- a/modelscan/issues.py
+++ b/modelscan/issues.py
@@ -142,3 +142,6 @@ class OperatorIssueDetails(IssueDetails):
             "source": f"{str(self.source)}",
             "scanner": f"{self.scanner}",
         }
+
+    def __repr__(self) -> str:
+        return f"<OperatorIssueDetails(module={self.module}, operator={self.operator}, source={str(self.source)})>"

--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -61,6 +61,7 @@ DEFAULT_SETTINGS = {
                     "exec",
                     "open",
                     "breakpoint",
+                    "__import__",
                 ],  # Pickle versions 0, 1, 2 have those function under '__builtin__'
                 "builtins": [
                     "eval",
@@ -70,6 +71,7 @@ DEFAULT_SETTINGS = {
                     "exec",
                     "open",
                     "breakpoint",
+                    "__import__",
                 ],  # Pickle versions 3, 4 have those function under 'builtins'
                 "runpy": "*",
                 "os": "*",
@@ -78,7 +80,11 @@ DEFAULT_SETTINGS = {
                 "socket": "*",
                 "subprocess": "*",
                 "sys": "*",
-                "operator": "attrgetter",  # Ex of code execution: operator.attrgetter("system")(__import__("os"))("echo pwned")
+                "operator": [
+                    "attrgetter",  # Ex of code execution: operator.attrgetter("system")(__import__("os"))("echo pwned")
+                ],
+                "pty": "*",
+                "pickle": "*",
             },
             "HIGH": {
                 "webbrowser": "*",  # Includes webbrowser.open()

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -341,7 +341,6 @@ def numpy_file_path(tmp_path_factory: Any) -> Any:
 
 
 def compare_results(resultList: List[Issue], expectedSet: Set[Issue]) -> None:
-    print(expectedSet)
     for result in resultList:
         assert result in expectedSet
     resultSet = set(resultList)


### PR DESCRIPTION
Add `__repr__` for debugging purposes for `OperatorIssueDetails`

Block `__import__` for builtins, all imports should be done through `INST`/`GLOBAL`/`STACK_GLOBAL` anyways

Fixed string (should be list) where `"operator": "attrgetter"` in blocklist

Blocked pty module (`pty.spawn('/bin/sh')`)

Blocked pickle module (`pickle.loads(bad_pickle)`)

Revamp the filtering so that instead of a direct comparison between used attribute name and blocked attribute, we use substrings to successfully block `eval.__call__`, for example, which was not previously blocked

Add malicious12 test case which uses `pickle.loads(malicious_pkl)`

Add malicious13 test case which uses `builtins`-`eval.__call__` to bypass previous blocklist functionality