### PR TITLE
Get scanners to load from settings and improve settings schema

### DIFF
--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -36,8 +36,6 @@ class ModelScan:
         self._load_scanners()
 
     def _load_scanners(self) -> None:
-        scanner_classes: Dict[str, ScanBase] = {}
-
         for scanner_path, scanner_settings in self._settings["scanners"].items():
             if (
                 "enabled" in scanner_settings.keys()
@@ -48,8 +46,10 @@ class ModelScan:
                     imported_module = importlib.import_module(
                         name=modulename, package=classname
                     )
-                    scanner_class = getattr(imported_module, classname)
-                    scanner_classes[scanner_path] = scanner_class
+
+                    scanner_class: ScanBase = getattr(imported_module, classname)
+                    self._scanners_to_run.append(scanner_class)
+
                 except Exception as e:
                     logger.error(f"Error importing scanner {scanner_path}")
                     self._init_errors.append(
@@ -57,13 +57,6 @@ class ModelScan:
                             scanner_path, f"Error importing scanner {scanner_path}: {e}"
                         )
                     )
-
-        scanners_to_run: List[ScanBase] = []
-        for scanner_class, scanner in scanner_classes.items():
-            is_enabled: bool = self._settings["scanners"][scanner_class]["enabled"]
-            if is_enabled:
-                scanners_to_run.append(scanner)
-        self._scanners_to_run = scanners_to_run
 
     def scan(
         self,

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -2,7 +2,7 @@ import logging
 import zipfile
 import importlib
 
-from modelscan.settings import DEFAULT_SCANNERS, DEFAULT_SETTINGS
+from modelscan.settings import DEFAULT_SETTINGS
 
 from pathlib import Path
 from typing import List, Union, Optional, IO, Dict, Tuple, Any
@@ -20,7 +20,6 @@ logger = logging.getLogger("modelscan")
 class ModelScan:
     def __init__(
         self,
-        scanners_to_load: List[str] = DEFAULT_SCANNERS,
         settings: Dict[str, Any] = DEFAULT_SETTINGS,
     ) -> None:
         # Output
@@ -33,38 +32,42 @@ class ModelScan:
         # Scanners
         self._scanners_to_run: List[ScanBase] = []
         self._settings: Dict[str, Any] = settings
-        self._load_scanners(scanners_to_load)
+        self._load_scanners()
 
-    def _load_scanners(self, scanners_to_load: List[str]) -> None:
+    def _load_scanners(self) -> None:
         scanner_classes: Dict[str, ScanBase] = {}
-        for scanner_path in scanners_to_load:
-            try:
-                (modulename, classname) = scanner_path.rsplit(".", 1)
-                imported_module = importlib.import_module(
-                    name=modulename, package=classname
-                )
-                scanner_class = getattr(imported_module, classname)
-                scanner_classes[scanner_path] = scanner_class
-            except Exception as e:
-                logger.error(f"Error importing scanner {scanner_path}")
-                self._errors.append(
-                    ModelScanError(
-                        scanner_path, f"Error importing scanner {scanner_path}: {e}"
+
+        for scanner_path, scanner_settings in self._settings["scanners"].items():
+            if (
+                "enabled" in scanner_settings.keys()
+                and self._settings["scanners"][scanner_path]["enabled"]
+            ):
+                try:
+                    (modulename, classname) = scanner_path.rsplit(".", 1)
+                    imported_module = importlib.import_module(
+                        name=modulename, package=classname
                     )
-                )
+                    scanner_class = getattr(imported_module, classname)
+                    scanner_classes[scanner_path] = scanner_class
+                except Exception as e:
+                    logger.error(f"Error importing scanner {scanner_path}")
+                    self._errors.append(
+                        ModelScanError(
+                            scanner_path, f"Error importing scanner {scanner_path}: {e}"
+                        )
+                    )
 
         scanners_to_run: List[ScanBase] = []
         for scanner_class, scanner in scanner_classes.items():
-            is_enabled: bool = self._settings["scanners"][scanner_class]["enabled"]
-            if is_enabled:
-                dep_error = scanner.handle_binary_dependencies()
-                if dep_error:
-                    logger.info(
-                        f"Skipping {scanner.full_name()} as it is missing dependencies"
-                    )
-                    self._errors.append(dep_error)
-                else:
-                    scanners_to_run.append(scanner)
+            dep_error = scanner.handle_binary_dependencies()
+            if dep_error:
+                logger.info(
+                    f"Skipping {scanner.full_name()} as it is missing dependencies"
+                )
+                self._errors.append(dep_error)
+            else:
+                scanners_to_run.append(scanner)
+
         self._scanners_to_run = scanners_to_run
 
     def scan(
@@ -114,7 +117,7 @@ class ModelScan:
     ) -> bool:
         scanned = False
         for scan_class in self._scanners_to_run:
-            scanner = scan_class(self._settings["scanners"])  # type: ignore[operator]
+            scanner = scan_class(self._settings)  # type: ignore[operator]
             scan_results = scanner.scan(
                 source=source,
                 data=data,

--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -25,7 +25,7 @@ class H5Scan(SavedModelScan):
     ) -> Optional[ScanResults]:
         if (
             not Path(source).suffix
-            in self._settings[H5Scan.full_name()]["supported_extensions"]
+            in self._settings["scanners"][H5Scan.full_name()]["supported_extensions"]
         ):
             return None
 

--- a/modelscan/scanners/keras/scan.py
+++ b/modelscan/scanners/keras/scan.py
@@ -21,7 +21,7 @@ class KerasScan(SavedModelScan):
     ) -> Optional[ScanResults]:
         if (
             not Path(source).suffix
-            in self._settings[KerasScan.full_name()]["supported_extensions"]
+            in self._settings["scanners"][KerasScan.full_name()]["supported_extensions"]
         ):
             return None
 

--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -20,7 +20,9 @@ class PyTorchScan(ScanBase):
     ) -> Optional[ScanResults]:
         if (
             not Path(source).suffix
-            in self._settings[PyTorchScan.full_name()]["supported_extensions"]
+            in self._settings["scanners"][PyTorchScan.full_name()][
+                "supported_extensions"
+            ]
         ):
             return None
 
@@ -52,7 +54,7 @@ class NumpyScan(ScanBase):
     ) -> Optional[ScanResults]:
         if (
             not Path(source).suffix
-            in self._settings[NumpyScan.full_name()]["supported_extensions"]
+            in self._settings["scanners"][NumpyScan.full_name()]["supported_extensions"]
         ):
             return None
 
@@ -81,7 +83,9 @@ class PickleScan(ScanBase):
     ) -> Optional[ScanResults]:
         if (
             not Path(source).suffix
-            in self._settings[PickleScan.full_name()]["supported_extensions"]
+            in self._settings["scanners"][PickleScan.full_name()][
+                "supported_extensions"
+            ]
         ):
             return None
 

--- a/modelscan/scanners/saved_model/scan.py
+++ b/modelscan/scanners/saved_model/scan.py
@@ -31,7 +31,9 @@ class SavedModelScan(ScanBase):
     ) -> Optional[ScanResults]:
         if (
             not Path(source).suffix
-            in self._settings[SavedModelScan.full_name()]["supported_extensions"]
+            in self._settings["scanners"][SavedModelScan.full_name()][
+                "supported_extensions"
+            ]
         ):
             return None
 
@@ -111,9 +113,9 @@ class SavedModelScan(ScanBase):
         source: Union[str, Path],
         settings: Dict[str, Any],
     ) -> ScanResults:
-        unsafe_operators: Dict[str, Any] = settings[SavedModelScan.full_name()][
-            "unsafe_tf_keras_operators"
-        ]
+        unsafe_operators: Dict[str, Any] = settings["scanners"][
+            SavedModelScan.full_name()
+        ]["unsafe_tf_keras_operators"]
 
         issues: List[Issue] = []
         all_operators = tensorflow.raw_ops.__dict__.keys()

--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -3,15 +3,6 @@ import tomlkit
 from typing import Any
 
 
-DEFAULT_SCANNERS = [
-    "modelscan.scanners.H5Scan",
-    "modelscan.scanners.KerasScan",
-    "modelscan.scanners.SavedModelScan",
-    "modelscan.scanners.NumpyScan",
-    "modelscan.scanners.PickleScan",
-    "modelscan.scanners.PyTorchScan",
-]
-
 DEFAULT_SETTINGS = {
     "supported_zip_extensions": [".zip", ".npz"],
     "scanners": {
@@ -51,44 +42,44 @@ DEFAULT_SETTINGS = {
             "enabled": True,
             "supported_extensions": [".bin", ".pt", ".pth", ".ckpt"],
         },
-        "unsafe_globals": {
-            "CRITICAL": {
-                "__builtin__": [
-                    "eval",
-                    "compile",
-                    "getattr",
-                    "apply",
-                    "exec",
-                    "open",
-                    "breakpoint",
-                ],  # Pickle versions 0, 1, 2 have those function under '__builtin__'
-                "builtins": [
-                    "eval",
-                    "compile",
-                    "getattr",
-                    "apply",
-                    "exec",
-                    "open",
-                    "breakpoint",
-                ],  # Pickle versions 3, 4 have those function under 'builtins'
-                "runpy": "*",
-                "os": "*",
-                "nt": "*",  # Alias for 'os' on Windows. Includes os.system()
-                "posix": "*",  # Alias for 'os' on Linux. Includes os.system()
-                "socket": "*",
-                "subprocess": "*",
-                "sys": "*",
-                "operator": "attrgetter",  # Ex of code execution: operator.attrgetter("system")(__import__("os"))("echo pwned")
-            },
-            "HIGH": {
-                "webbrowser": "*",  # Includes webbrowser.open()
-                "httplib": "*",  # Includes http.client.HTTPSConnection()
-                "requests.api": "*",
-                "aiohttp.client": "*",
-            },
-            "MEDIUM": {},
-            "LOW": {},
+    },
+    "unsafe_globals": {
+        "CRITICAL": {
+            "__builtin__": [
+                "eval",
+                "compile",
+                "getattr",
+                "apply",
+                "exec",
+                "open",
+                "breakpoint",
+            ],  # Pickle versions 0, 1, 2 have those function under '__builtin__'
+            "builtins": [
+                "eval",
+                "compile",
+                "getattr",
+                "apply",
+                "exec",
+                "open",
+                "breakpoint",
+            ],  # Pickle versions 3, 4 have those function under 'builtins'
+            "runpy": "*",
+            "os": "*",
+            "nt": "*",  # Alias for 'os' on Windows. Includes os.system()
+            "posix": "*",  # Alias for 'os' on Linux. Includes os.system()
+            "socket": "*",
+            "subprocess": "*",
+            "sys": "*",
+            "operator": "attrgetter",  # Ex of code execution: operator.attrgetter("system")(__import__("os"))("echo pwned")
         },
+        "HIGH": {
+            "webbrowser": "*",  # Includes webbrowser.open()
+            "httplib": "*",  # Includes http.client.HTTPSConnection()
+            "requests.api": "*",
+            "aiohttp.client": "*",
+        },
+        "MEDIUM": {},
+        "LOW": {},
     },
 }
 

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -32,7 +32,7 @@ from modelscan.tools.picklescanner import (
 )
 from modelscan.settings import DEFAULT_SETTINGS
 
-settings: Dict[str, Any] = DEFAULT_SETTINGS["scanners"]  # type: ignore[assignment]
+settings: Dict[str, Any] = DEFAULT_SETTINGS
 
 
 class Malicious1:


### PR DESCRIPTION
Changes `ModelScan` initialization so it reads the scanners to load from which ones are enabled in the settings instead of having an additional argument. This allows for custom scanners to be used through the CLI

Also updates the settings schema for clarity so the `unsafe_operators` are a separate field from `scanners`