### PR TITLE
Fix Scanner Dependency Error Messages

### DIFF
--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -72,7 +72,6 @@ class ModelScan:
         path: Union[str, Path],
     ) -> Dict[str, Any]:
         self._issues = Issues()
-        self._errors = []
         self._skipped = []
         self._scanned = []
         self._input_path = str(path)

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -26,6 +26,7 @@ class ModelScan:
         # Output
         self._issues = Issues()
         self._errors: List[Error] = []
+        self._init_errors: List[Error] = []
         self._skipped: List[str] = []
         self._scanned: List[str] = []
         self._input_path: str = ""
@@ -47,7 +48,7 @@ class ModelScan:
                 scanner_classes[scanner_path] = scanner_class
             except Exception as e:
                 logger.error(f"Error importing scanner {scanner_path}")
-                self._errors.append(
+                self._init_errors.append(
                     ModelScanError(
                         scanner_path, f"Error importing scanner {scanner_path}: {e}"
                     )
@@ -57,14 +58,7 @@ class ModelScan:
         for scanner_class, scanner in scanner_classes.items():
             is_enabled: bool = self._settings["scanners"][scanner_class]["enabled"]
             if is_enabled:
-                dep_error = scanner.handle_binary_dependencies()
-                if dep_error:
-                    logger.info(
-                        f"Skipping {scanner.full_name()} as it is missing dependencies"
-                    )
-                    self._errors.append(dep_error)
-                else:
-                    scanners_to_run.append(scanner)
+                scanners_to_run.append(scanner)
         self._scanners_to_run = scanners_to_run
 
     def scan(
@@ -72,6 +66,8 @@ class ModelScan:
         path: Union[str, Path],
     ) -> Dict[str, Any]:
         self._issues = Issues()
+        self._errors = []
+        self._errors.extend(self._init_errors)
         self._skipped = []
         self._scanned = []
         self._input_path = str(path)

--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -29,6 +29,10 @@ class H5Scan(SavedModelScan):
         ):
             return None
 
+        dep_error = self.handle_binary_dependencies()
+        if dep_error:
+            return ScanResults([], [dep_error])
+
         if data:
             logger.warning(
                 "H5 scanner got data bytes. It only support direct file scanning."

--- a/modelscan/scanners/keras/scan.py
+++ b/modelscan/scanners/keras/scan.py
@@ -25,6 +25,10 @@ class KerasScan(SavedModelScan):
         ):
             return None
 
+        dep_error = self.handle_binary_dependencies()
+        if dep_error:
+            return ScanResults([], [dep_error])
+
         try:
             with zipfile.ZipFile(data or source, "r") as zip:
                 file_names = zip.namelist()

--- a/modelscan/scanners/saved_model/scan.py
+++ b/modelscan/scanners/saved_model/scan.py
@@ -35,6 +35,10 @@ class SavedModelScan(ScanBase):
         ):
             return None
 
+        dep_error = self.handle_binary_dependencies()
+        if dep_error:
+            return ScanResults([], [dep_error])
+
         if data:
             results = self._scan(source, data)
 


### PR DESCRIPTION
Scanner dependency error messages were not populating since the error list was being cleared at the start of each scan. Changes the errors during initialization to be stored separately to populate in each scan, and changes dependency errors to only be created when a valid scan of that type is starting for SavedModel, Keras, and H5 scanners that have the optional dependencies.