### PR TITLE
Add is_compatible API

### DIFF
--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -175,16 +175,18 @@ class ModelScan:
         return report
 
     def is_compatible(self, path: str) -> bool:
-        # Determines whether a single file path is compatible with any of the available scanners
+        # Determines whether a file path is compatible with any of the available scanners
         compatible: bool = False
 
+        if Path(path).suffix in self._settings["supported_zip_extensions"]:
+            return True
         for scanner_path, scanner_settings in self._settings["scanners"].items():
             if (
                 "supported_extensions" in scanner_settings.keys()
                 and Path(path).suffix
                 in self._settings["scanners"][scanner_path]["supported_extensions"]
             ):
-                compatible = True
+                return True
 
         return compatible
 

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -174,6 +174,20 @@ class ModelScan:
 
         return report
 
+    def is_compatible(self, path: str) -> bool:
+        # Determines whether a single file path is compatible with any of the available scanners
+        compatible: bool = False
+
+        for scanner_path, scanner_settings in self._settings["scanners"].items():
+            if (
+                "supported_extensions" in scanner_settings.keys()
+                and Path(path).suffix
+                in self._settings["scanners"][scanner_path]["supported_extensions"]
+            ):
+                compatible = True
+
+        return compatible
+
     @property
     def issues(self) -> Issues:
         return self._issues

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -176,8 +176,6 @@ class ModelScan:
 
     def is_compatible(self, path: str) -> bool:
         # Determines whether a file path is compatible with any of the available scanners
-        compatible: bool = False
-
         if Path(path).suffix in self._settings["supported_zip_extensions"]:
             return True
         for scanner_path, scanner_settings in self._settings["scanners"].items():
@@ -188,7 +186,7 @@ class ModelScan:
             ):
                 return True
 
-        return compatible
+        return False
 
     @property
     def issues(self) -> Issues:


### PR DESCRIPTION
Adds `is_compatible` API to ModelScan objects that checks whether a single file path is compatible with any of the supported file extensions of the available scanners

Does not open directories or zipfiles and only checks zipfiles on supported_zip_extensions

closes #90 