### PR TITLE
Skip H5 files with no model_config

### DIFF
--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -31,6 +31,10 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
         ):
             return None
 
+        with h5py.File(source, "r") as model_hdf5:
+            if not hasattr(model_hdf5, "model_config"):
+                return None  # skip file if there is no model_config
+
         dep_error = self.handle_binary_dependencies()
         if dep_error:
             return ScanResults([], [dep_error])


### PR DESCRIPTION
Modelscan was failing on h5 files that have no model_config attribute
Adds a check for a model_config and skips the H5LambdaDetectScan scan if there isn't one

Closes #93 