### PR TITLE
Update tests to check skipped and scanned

### DIFF
--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -50,7 +50,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
     def _scan_keras_h5_file(self, source: Union[str, Path]) -> Optional[ScanResults]:
         machine_learning_library_name = "Keras"
         operators_in_model = self._get_keras_h5_operator_names(source)
-        if not operators_in_model:
+        if operators_in_model is None:
             return None
         return H5LambdaDetectScan._check_for_unsafe_tf_keras_operator(
             module_name=machine_learning_library_name,

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -454,36 +454,37 @@ def test_scan_zip(zip_file_path: Any) -> None:
     ]
 
     ms = ModelScan()
-    # ms._scan_zip(f"{zip_file_path}/test.zip")
     results = ms.scan(f"{zip_file_path}/test.zip")
-    assert results["scanned"]["scanned_files"] == [f"{zip_file_path}/test.zip:data.pkl"]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["scanned"]["scanned_files"] == [
+        f"{zip_file_path}/test.zip:data.pkl"
+    ]
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == expected
 
 
 def test_scan_pytorch(pytorch_file_path: Any) -> None:
     ms = ModelScan()
     results = ms.scan(Path(f"{pytorch_file_path}/bad_pytorch.pt"))
-    assert results["scanned"]["scanned_files"] == [
+    assert results["summary"]["scanned"]["scanned_files"] == [
         f"{pytorch_file_path}/bad_pytorch.pt"
     ]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == []
     assert [error.scan_name for error in ms.errors] == ["pytorch"]  # type: ignore[attr-defined]
 
     results = ms.scan(Path(f"{pytorch_file_path}/safe_zip_pytorch.pt"))
-    assert results["scanned"]["scanned_files"] == [
+    assert results["summary"]["scanned"]["scanned_files"] == [
         f"{pytorch_file_path}/safe_zip_pytorch.pt:safe_zip_pytorch/data.pkl"
     ]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == []
     assert results["errors"] == []
 
     results = ms.scan(Path(f"{pytorch_file_path}/safe_old_format_pytorch.pt"))
-    assert results["scanned"]["scanned_files"] == [
+    assert results["summary"]["scanned"]["scanned_files"] == [
         f"{pytorch_file_path}/safe_old_format_pytorch.pt"
     ]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == []
     assert results["errors"] == []
 
@@ -501,10 +502,10 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
         ),
     ]
     results = ms.scan(unsafe_zip_path)
-    assert results["scanned"]["scanned_files"] == [
+    assert results["summary"]["scanned"]["scanned_files"] == [
         f"{pytorch_file_path}/unsafe_zip_pytorch.pt:unsafe_zip_pytorch/data.pkl"
     ]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == expected
     assert results["errors"] == []
 
@@ -513,8 +514,10 @@ def test_scan_numpy(numpy_file_path: Any) -> None:
     ms = ModelScan()
     results = ms.scan(f"{numpy_file_path}/safe_numpy.npy")
     assert ms.issues.all_issues == []
-    assert results["scanned"]["scanned_files"] == [f"{numpy_file_path}/safe_numpy.npy"]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["scanned"]["scanned_files"] == [
+        f"{numpy_file_path}/safe_numpy.npy"
+    ]
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
     expected = {
@@ -522,17 +525,20 @@ def test_scan_numpy(numpy_file_path: Any) -> None:
             IssueCode.UNSAFE_OPERATOR,
             IssueSeverity.CRITICAL,
             OperatorIssueDetails(
-                "builtins", "exec", IssueSeverity.CRITICAL, "unsafe_numpy.npy"
+                "builtins",
+                "exec",
+                IssueSeverity.CRITICAL,
+                f"{numpy_file_path}/unsafe_numpy.npy",
             ),
         ),
     }
 
     results = ms.scan(f"{numpy_file_path}/unsafe_numpy.npy")
     compare_results(ms.issues.all_issues, expected)
-    assert results["scanned"]["scanned_files"] == [
+    assert results["summary"]["scanned"]["scanned_files"] == [
         f"{numpy_file_path}/unsafe_numpy.npy"
     ]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
 
@@ -540,15 +546,19 @@ def test_scan_file_path(file_path: Any) -> None:
     benign_pickle = ModelScan()
     results = benign_pickle.scan(Path(f"{file_path}/data/benign0_v3.pkl"))
     assert benign_pickle.issues.all_issues == []
-    assert results["scanned"]["scanned_files"] == [f"{file_path}/data/benign0_v3.pkl"]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["scanned"]["scanned_files"] == [
+        f"{file_path}/data/benign0_v3.pkl"
+    ]
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
     benign_dill = ModelScan()
     results = benign_dill.scan(Path(f"{file_path}/data/benign0_v3.dill"))
     assert benign_dill.issues.all_issues == []
-    assert results["scanned"]["scanned_files"] == [f"{file_path}/data/benign0_v3.dill"]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["scanned"]["scanned_files"] == [
+        f"{file_path}/data/benign0_v3.dill"
+    ]
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
     malicious0 = ModelScan()
@@ -596,8 +606,10 @@ def test_scan_file_path(file_path: Any) -> None:
     }
     results = malicious0.scan(Path(f"{file_path}/data/malicious0.pkl"))
     compare_results(malicious0.issues.all_issues, expected_malicious0)
-    assert results["scanned"]["scanned_files"] == [f"{file_path}/data/malicious0.pkl"]
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["scanned"]["scanned_files"] == [
+        f"{file_path}/data/malicious0.pkl"
+    ]
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
 
@@ -1191,7 +1203,7 @@ def test_scan_directory_path(file_path: str) -> None:
     p = Path(f"{file_path}/data/")
     results = ms.scan(p)
     compare_results(ms.issues.all_issues, expected)
-    assert set(results["scanned"]["scanned_files"]) == {
+    assert set(results["summary"]["scanned"]["scanned_files"]) == {
         f"{p}/malicious1.zip:data.pkl",
         f"{p}/malicious0.pkl",
         f"{p}/malicious3.pkl",
@@ -1221,7 +1233,7 @@ def test_scan_directory_path(file_path: str) -> None:
         f"{p}/benign0_v3.dill",
         f"{p}/benign0_v4.dill",
     }
-    assert results["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
 
@@ -1246,18 +1258,18 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
 
     assert ms.issues.all_issues == []
     if file_extension == ".pb":
-        assert set(results["scanned"]["scanned_files"]) == {
+        assert set(results["summary"]["scanned"]["scanned_files"]) == {
             f"{safe_filename}/fingerprint.pb",
             f"{safe_filename}/keras_metadata.pb",
             f"{safe_filename}/saved_model.pb",
         }
-        assert set(results["skipped"]["skipped_files"]) == {
+        assert set(results["summary"]["skipped"]["skipped_files"]) == {
             f"{safe_filename}/variables/variables.data-00000-of-00001",
             f"{safe_filename}/variables/variables.index",
         }
     else:
-        assert results["scanned"]["scanned_files"] == [safe_filename]
-        assert results["skipped"]["skipped_files"] == []
+        assert results["summary"]["scanned"]["scanned_files"] == [safe_filename]
+        assert results["summary"]["skipped"]["skipped_files"] == []
 
     assert results["errors"] == []
 
@@ -1343,18 +1355,18 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
     assert results["errors"] == []
 
     if file_extension == ".pb":
-        assert set(results["scanned"]["scanned_files"]) == {
+        assert set(results["summary"]["scanned"]["scanned_files"]) == {
             f"{unsafe_filename}/fingerprint.pb",
             f"{unsafe_filename}/keras_metadata.pb",
             f"{unsafe_filename}/saved_model.pb",
         }
-        assert set(results["skipped"]["skipped_files"]) == {
+        assert set(results["summary"]["skipped"]["skipped_files"]) == {
             f"{unsafe_filename}/variables/variables.data-00000-of-00001",
             f"{unsafe_filename}/variables/variables.index",
         }
     else:
-        assert results["scanned"]["scanned_files"] == [unsafe_filename]
-        assert results["skipped"]["skipped_files"] == []
+        assert results["summary"]["scanned"]["scanned_files"] == [unsafe_filename]
+        assert results["summary"]["skipped"]["skipped_files"] == []
 
 
 def test_scan_tensorflow(tensorflow_file_path: Any) -> None:
@@ -1365,12 +1377,12 @@ def test_scan_tensorflow(tensorflow_file_path: Any) -> None:
     ms = ModelScan()
     results = ms.scan(Path(f"{safe_tensorflow_model_dir}"))
     assert ms.issues.all_issues == []
-    assert set(results["scanned"]["scanned_files"]) == {
+    assert set(results["summary"]["scanned"]["scanned_files"]) == {
         f"{safe_tensorflow_model_dir}/fingerprint.pb",
         f"{safe_tensorflow_model_dir}/keras_metadata.pb",
         f"{safe_tensorflow_model_dir}/saved_model.pb",
     }
-    assert set(results["skipped"]["skipped_files"]) == {
+    assert set(results["summary"]["skipped"]["skipped_files"]) == {
         f"{safe_tensorflow_model_dir}/variables/variables.data-00000-of-00001",
         f"{safe_tensorflow_model_dir}/variables/variables.index",
     }
@@ -1402,12 +1414,12 @@ def test_scan_tensorflow(tensorflow_file_path: Any) -> None:
     results = ms.scan(Path(f"{unsafe_tensorflow_model_dir}"))
 
     assert ms.issues.all_issues == expected
-    assert set(results["scanned"]["scanned_files"]) == {
+    assert set(results["summary"]["scanned"]["scanned_files"]) == {
         f"{unsafe_tensorflow_model_dir}/fingerprint.pb",
         f"{unsafe_tensorflow_model_dir}/keras_metadata.pb",
         f"{unsafe_tensorflow_model_dir}/saved_model.pb",
     }
-    assert set(results["skipped"]["skipped_files"]) == {
+    assert set(results["summary"]["skipped"]["skipped_files"]) == {
         f"{unsafe_tensorflow_model_dir}/variables/variables.data-00000-of-00001",
         f"{unsafe_tensorflow_model_dir}/variables/variables.index",
     }

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -455,9 +455,7 @@ def test_scan_zip(zip_file_path: Any) -> None:
 
     ms = ModelScan()
     results = ms.scan(f"{zip_file_path}/test.zip")
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{zip_file_path}/test.zip:data.pkl"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"test.zip:data.pkl"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == expected
 
@@ -465,16 +463,14 @@ def test_scan_zip(zip_file_path: Any) -> None:
 def test_scan_pytorch(pytorch_file_path: Any) -> None:
     ms = ModelScan()
     results = ms.scan(Path(f"{pytorch_file_path}/bad_pytorch.pt"))
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{pytorch_file_path}/bad_pytorch.pt"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"bad_pytorch.pt"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == []
     assert [error.scan_name for error in ms.errors] == ["pytorch"]  # type: ignore[attr-defined]
 
     results = ms.scan(Path(f"{pytorch_file_path}/safe_zip_pytorch.pt"))
     assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{pytorch_file_path}/safe_zip_pytorch.pt:safe_zip_pytorch/data.pkl"
+        f"safe_zip_pytorch.pt:safe_zip_pytorch/data.pkl"
     ]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == []
@@ -482,7 +478,7 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
 
     results = ms.scan(Path(f"{pytorch_file_path}/safe_old_format_pytorch.pt"))
     assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{pytorch_file_path}/safe_old_format_pytorch.pt"
+        f"safe_old_format_pytorch.pt"
     ]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == []
@@ -503,7 +499,7 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
     ]
     results = ms.scan(unsafe_zip_path)
     assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{pytorch_file_path}/unsafe_zip_pytorch.pt:unsafe_zip_pytorch/data.pkl"
+        f"unsafe_zip_pytorch.pt:unsafe_zip_pytorch/data.pkl"
     ]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert ms.issues.all_issues == expected
@@ -514,9 +510,7 @@ def test_scan_numpy(numpy_file_path: Any) -> None:
     ms = ModelScan()
     results = ms.scan(f"{numpy_file_path}/safe_numpy.npy")
     assert ms.issues.all_issues == []
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{numpy_file_path}/safe_numpy.npy"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"safe_numpy.npy"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
@@ -535,9 +529,7 @@ def test_scan_numpy(numpy_file_path: Any) -> None:
 
     results = ms.scan(f"{numpy_file_path}/unsafe_numpy.npy")
     compare_results(ms.issues.all_issues, expected)
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{numpy_file_path}/unsafe_numpy.npy"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"unsafe_numpy.npy"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
@@ -546,18 +538,14 @@ def test_scan_file_path(file_path: Any) -> None:
     benign_pickle = ModelScan()
     results = benign_pickle.scan(Path(f"{file_path}/data/benign0_v3.pkl"))
     assert benign_pickle.issues.all_issues == []
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{file_path}/data/benign0_v3.pkl"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"benign0_v3.pkl"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
     benign_dill = ModelScan()
     results = benign_dill.scan(Path(f"{file_path}/data/benign0_v3.dill"))
     assert benign_dill.issues.all_issues == []
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{file_path}/data/benign0_v3.dill"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"benign0_v3.dill"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
@@ -606,9 +594,7 @@ def test_scan_file_path(file_path: Any) -> None:
     }
     results = malicious0.scan(Path(f"{file_path}/data/malicious0.pkl"))
     compare_results(malicious0.issues.all_issues, expected_malicious0)
-    assert results["summary"]["scanned"]["scanned_files"] == [
-        f"{file_path}/data/malicious0.pkl"
-    ]
+    assert results["summary"]["scanned"]["scanned_files"] == [f"malicious0.pkl"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
 
@@ -1204,34 +1190,34 @@ def test_scan_directory_path(file_path: str) -> None:
     results = ms.scan(p)
     compare_results(ms.issues.all_issues, expected)
     assert set(results["summary"]["scanned"]["scanned_files"]) == {
-        f"{p}/malicious1.zip:data.pkl",
-        f"{p}/malicious0.pkl",
-        f"{p}/malicious3.pkl",
-        f"{p}/malicious6.pkl",
-        f"{p}/malicious7.pkl",
-        f"{p}/malicious8.pkl",
-        f"{p}/malicious9.pkl",
-        f"{p}/malicious10.pkl",
-        f"{p}/malicious11.pkl",
-        f"{p}/malicious12.pkl",
-        f"{p}/malicious13.pkl",
-        f"{p}/malicious1_v0.dill",
-        f"{p}/malicious1_v3.dill",
-        f"{p}/malicious1_v4.dill",
-        f"{p}/malicious4.pickle",
-        f"{p}/malicious5.pickle",
-        f"{p}/malicious1_v0.pkl",
-        f"{p}/malicious1_v3.pkl",
-        f"{p}/malicious1_v4.pkl",
-        f"{p}/malicious2_v0.pkl",
-        f"{p}/malicious2_v3.pkl",
-        f"{p}/malicious2_v4.pkl",
-        f"{p}/benign0_v0.pkl",
-        f"{p}/benign0_v3.pkl",
-        f"{p}/benign0_v4.pkl",
-        f"{p}/benign0_v0.dill",
-        f"{p}/benign0_v3.dill",
-        f"{p}/benign0_v4.dill",
+        f"malicious1.zip:data.pkl",
+        f"malicious0.pkl",
+        f"malicious3.pkl",
+        f"malicious6.pkl",
+        f"malicious7.pkl",
+        f"malicious8.pkl",
+        f"malicious9.pkl",
+        f"malicious10.pkl",
+        f"malicious11.pkl",
+        f"malicious12.pkl",
+        f"malicious13.pkl",
+        f"malicious1_v0.dill",
+        f"malicious1_v3.dill",
+        f"malicious1_v4.dill",
+        f"malicious4.pickle",
+        f"malicious5.pickle",
+        f"malicious1_v0.pkl",
+        f"malicious1_v3.pkl",
+        f"malicious1_v4.pkl",
+        f"malicious2_v0.pkl",
+        f"malicious2_v3.pkl",
+        f"malicious2_v4.pkl",
+        f"benign0_v0.pkl",
+        f"benign0_v3.pkl",
+        f"benign0_v4.pkl",
+        f"benign0_v0.dill",
+        f"benign0_v3.dill",
+        f"benign0_v4.dill",
     }
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
@@ -1259,16 +1245,18 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
     assert ms.issues.all_issues == []
     if file_extension == ".pb":
         assert set(results["summary"]["scanned"]["scanned_files"]) == {
-            f"{safe_filename}/fingerprint.pb",
-            f"{safe_filename}/keras_metadata.pb",
-            f"{safe_filename}/saved_model.pb",
+            f"fingerprint.pb",
+            f"keras_metadata.pb",
+            f"saved_model.pb",
         }
         assert set(results["summary"]["skipped"]["skipped_files"]) == {
-            f"{safe_filename}/variables/variables.data-00000-of-00001",
-            f"{safe_filename}/variables/variables.index",
+            f"variables/variables.data-00000-of-00001",
+            f"variables/variables.index",
         }
     else:
-        assert results["summary"]["scanned"]["scanned_files"] == [safe_filename]
+        assert results["summary"]["scanned"]["scanned_files"] == [
+            f"safe{file_extension}"
+        ]
         assert results["summary"]["skipped"]["skipped_files"] == []
 
     assert results["errors"] == []
@@ -1356,16 +1344,18 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
 
     if file_extension == ".pb":
         assert set(results["summary"]["scanned"]["scanned_files"]) == {
-            f"{unsafe_filename}/fingerprint.pb",
-            f"{unsafe_filename}/keras_metadata.pb",
-            f"{unsafe_filename}/saved_model.pb",
+            f"fingerprint.pb",
+            f"keras_metadata.pb",
+            f"saved_model.pb",
         }
         assert set(results["summary"]["skipped"]["skipped_files"]) == {
-            f"{unsafe_filename}/variables/variables.data-00000-of-00001",
-            f"{unsafe_filename}/variables/variables.index",
+            f"variables/variables.data-00000-of-00001",
+            f"variables/variables.index",
         }
     else:
-        assert results["summary"]["scanned"]["scanned_files"] == [unsafe_filename]
+        assert results["summary"]["scanned"]["scanned_files"] == [
+            f"unsafe{file_extension}"
+        ]
         assert results["summary"]["skipped"]["skipped_files"] == []
 
 
@@ -1378,13 +1368,13 @@ def test_scan_tensorflow(tensorflow_file_path: Any) -> None:
     results = ms.scan(Path(f"{safe_tensorflow_model_dir}"))
     assert ms.issues.all_issues == []
     assert set(results["summary"]["scanned"]["scanned_files"]) == {
-        f"{safe_tensorflow_model_dir}/fingerprint.pb",
-        f"{safe_tensorflow_model_dir}/keras_metadata.pb",
-        f"{safe_tensorflow_model_dir}/saved_model.pb",
+        f"fingerprint.pb",
+        f"keras_metadata.pb",
+        f"saved_model.pb",
     }
     assert set(results["summary"]["skipped"]["skipped_files"]) == {
-        f"{safe_tensorflow_model_dir}/variables/variables.data-00000-of-00001",
-        f"{safe_tensorflow_model_dir}/variables/variables.index",
+        f"variables/variables.data-00000-of-00001",
+        f"variables/variables.index",
     }
     assert results["errors"] == []
 
@@ -1415,13 +1405,13 @@ def test_scan_tensorflow(tensorflow_file_path: Any) -> None:
 
     assert ms.issues.all_issues == expected
     assert set(results["summary"]["scanned"]["scanned_files"]) == {
-        f"{unsafe_tensorflow_model_dir}/fingerprint.pb",
-        f"{unsafe_tensorflow_model_dir}/keras_metadata.pb",
-        f"{unsafe_tensorflow_model_dir}/saved_model.pb",
+        f"fingerprint.pb",
+        f"keras_metadata.pb",
+        f"saved_model.pb",
     }
     assert set(results["summary"]["skipped"]["skipped_files"]) == {
-        f"{unsafe_tensorflow_model_dir}/variables/variables.data-00000-of-00001",
-        f"{unsafe_tensorflow_model_dir}/variables/variables.index",
+        f"variables/variables.data-00000-of-00001",
+        f"variables/variables.index",
     }
     assert results["errors"] == []
 


### PR DESCRIPTION
H5LambdaDetectScan was returning None on clean files since their unsafe operator list was empty. Changes handling for this

Adds checks to the tests for the correct skipped and scanned file lists in the modelscan results