### PR TITLE
Nested Zip Handling

### DIFF
--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -127,20 +127,18 @@ class ModelScan:
                 file_names = zip.namelist()
                 for file_name in file_names:
                     with zip.open(file_name, "r") as file_io:
-                        if _is_zipfile(file_name, data=file_io):
-                            scanned = False
-                            self._errors.append(
-                                ModelScanError(
-                                    "ModelScan",
-                                    f"{source}:{file_name} is a zip file. ModelScan does not support nested zip files.",
-                                )
-                            )
-                        else:
-                            scanned = self._scan_source(
-                                source=f"{source}:{file_name}",
-                                data=file_io,
-                            )
+                        scanned = self._scan_source(
+                            source=f"{source}:{file_name}",
+                            data=file_io,
+                        )
                         if not scanned:
+                            if _is_zipfile(file_name, data=file_io):
+                                self._errors.append(
+                                    ModelScanError(
+                                        "ModelScan",
+                                        f"{source}:{file_name} is a zip file. ModelScan does not support nested zip files.",
+                                    )
+                                )
                             self._skipped.append(f"{source}:{file_name}")
         except zipfile.BadZipFile as e:
             logger.debug(f"Skipping zip file {source}, due to error", e, exc_info=True)

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -127,10 +127,21 @@ class ModelScan:
                 file_names = zip.namelist()
                 for file_name in file_names:
                     with zip.open(file_name, "r") as file_io:
-                        self._scan_source(
-                            source=f"{source}:{file_name}",
-                            data=file_io,
-                        )
+                        if _is_zipfile(file_name, data=file_io):
+                            scanned = False
+                            self._errors.append(
+                                ModelScanError(
+                                    "ModelScan",
+                                    f"{source}:{file_name} is a zip file. ModelScan does not support nested zip files.",
+                                )
+                            )
+                        else:
+                            scanned = self._scan_source(
+                                source=f"{source}:{file_name}",
+                                data=file_io,
+                            )
+                        if not scanned:
+                            self._skipped.append(f"{source}:{file_name}")
         except zipfile.BadZipFile as e:
             logger.debug(f"Skipping zip file {source}, due to error", e, exc_info=True)
             self._skipped.append(str(source))

--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -27,7 +27,7 @@ class PyTorchUnsafeOpScan(ScanBase):
         ):
             return None
 
-        if _is_zipfile(source):
+        if _is_zipfile(source, data):
             return None
 
         if data:

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -472,7 +472,11 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
     assert results["summary"]["scanned"]["scanned_files"] == [
         f"safe_zip_pytorch.pt:safe_zip_pytorch/data.pkl"
     ]
-    assert results["summary"]["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == [
+        "safe_zip_pytorch.pt:safe_zip_pytorch/byteorder",
+        "safe_zip_pytorch.pt:safe_zip_pytorch/version",
+        "safe_zip_pytorch.pt:safe_zip_pytorch/.data/serialization_id",
+    ]
     assert ms.issues.all_issues == []
     assert results["errors"] == []
 
@@ -499,9 +503,13 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
     ]
     results = ms.scan(unsafe_zip_path)
     assert results["summary"]["scanned"]["scanned_files"] == [
-        f"unsafe_zip_pytorch.pt:unsafe_zip_pytorch/data.pkl"
+        f"unsafe_zip_pytorch.pt:unsafe_zip_pytorch/data.pkl",
     ]
-    assert results["summary"]["skipped"]["skipped_files"] == []
+    assert results["summary"]["skipped"]["skipped_files"] == [
+        "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/byteorder",
+        "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/version",
+        "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/.data/serialization_id",
+    ]
     assert ms.issues.all_issues == expected
     assert results["errors"] == []
 
@@ -1257,7 +1265,14 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
         assert results["summary"]["scanned"]["scanned_files"] == [
             f"safe{file_extension}"
         ]
-        assert results["summary"]["skipped"]["skipped_files"] == []
+        if file_extension == ".keras":
+            assert results["summary"]["skipped"]["skipped_files"] == [
+                f"safe{file_extension}:metadata.json",
+                f"safe{file_extension}:config.json",
+                f"safe{file_extension}:model.weights.h5",
+            ]
+        else:
+            assert results["summary"]["skipped"]["skipped_files"] == []
 
     assert results["errors"] == []
 
@@ -1356,7 +1371,14 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
         assert results["summary"]["scanned"]["scanned_files"] == [
             f"unsafe{file_extension}"
         ]
-        assert results["summary"]["skipped"]["skipped_files"] == []
+        if file_extension == ".keras":
+            assert results["summary"]["skipped"]["skipped_files"] == [
+                f"unsafe{file_extension}:metadata.json",
+                f"unsafe{file_extension}:config.json",
+                f"unsafe{file_extension}:model.weights.h5",
+            ]
+        else:
+            assert results["summary"]["skipped"]["skipped_files"] == []
 
 
 def test_scan_tensorflow(tensorflow_file_path: Any) -> None:


### PR DESCRIPTION
Adds an error to the results if a zip file scanned contains another zip file that is not scanned by any existing scanners.

Expected behavior:
- Zip file contains a keras file: zip will be unzipped, keras will be scanned, no error
- Zip file contains a new pytorch file or other zip file: zip will be unzipped, inner zip or pytorch will be attempted to be scanned with no results, ModelScan error is added to results that nested zips are not supported