### PR TITLE
fix symlink issue in path resolution

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,5 @@
+default_language_version:
+    python: python3.11
 repos:
   - repo: https://github.com/psf/black
     rev: 22.8.0

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -220,10 +220,19 @@ class ModelScan:
         report["summary"]["scanned"] = {"total_scanned": len(self._scanned)}
 
         if self._scanned:
-            report["summary"]["scanned"]["scanned_files"] = [
-                str(Path(file_name).relative_to(Path(absolute_path)))
-                for file_name in self._scanned
-            ]
+            scanned_files = []
+            try:
+                for file_name in self._scanned:
+                    resolved_file = Path(file_name).resolve()
+                    scanned_files.append(
+                        str(resolved_file.relative_to(Path(absolute_path)))
+                    )
+            except Exception:
+                logger.warning(
+                    f"Could not record scanned file {file_name}", exc_info=True
+                )
+
+            report["summary"]["scanned"]["scanned_files"] = scanned_files
 
         if self._issues.all_issues:
             report["issues"] = [
@@ -245,8 +254,9 @@ class ModelScan:
                 if error.message:
                     error_information["description"] = error.message
                 if error.source is not None:
+                    resolved_file = Path(error.source).resolve()
                     error_information["source"] = str(
-                        Path(str(error.source)).relative_to(Path(absolute_path))
+                        resolved_file.relative_to(Path(absolute_path))
                     )
 
                 all_errors.append(error_information)
@@ -261,8 +271,9 @@ class ModelScan:
                 skipped_file_information = {}
                 skipped_file_information["category"] = str(skipped_file.category.name)
                 skipped_file_information["description"] = str(skipped_file.message)
+                resolved_file = Path(skipped_file.source).resolve()
                 skipped_file_information["source"] = str(
-                    Path(skipped_file.source).relative_to(Path(absolute_path))
+                    resolved_file.relative_to(Path(absolute_path))
                 )
                 all_skipped_files.append(skipped_file_information)
 

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -221,15 +221,10 @@ class ModelScan:
 
         if self._scanned:
             scanned_files = []
-            try:
-                for file_name in self._scanned:
-                    resolved_file = Path(file_name).resolve()
-                    scanned_files.append(
-                        str(resolved_file.relative_to(Path(absolute_path)))
-                    )
-            except Exception:
-                logger.warning(
-                    f"Could not record scanned file {file_name}", exc_info=True
+            for file_name in self._scanned:
+                resolved_file = Path(file_name).resolve()
+                scanned_files.append(
+                    str(resolved_file.relative_to(Path(absolute_path)))
                 )
 
             report["summary"]["scanned"]["scanned_files"] = scanned_files
@@ -240,9 +235,8 @@ class ModelScan:
             ]
 
             for issue in report["issues"]:
-                issue["source"] = str(
-                    Path(issue["source"]).relative_to(Path(absolute_path))
-                )
+                resolved_file = Path(issue["source"]).resolve()
+                issue["source"] = str(resolved_file.relative_to(Path(absolute_path)))
         else:
             report["issues"] = []
 


### PR DESCRIPTION
When passing a path that includes a symlink to `scan`, it messes up the path resolution logic because we are calling `resolve` (which removes symlinks) on the absolute path, but not on the individual file paths. So when we try to do `relative_to`, the absolute path is NOT using symlinks, and the file_path IS using symlinks, which causes a path mismatch. 
This change should fix this.