### PR TITLE
Fixed a typo in model saving directory.

### DIFF
--- a/notebooks/xgboost_diabetes_classification.ipynb
+++ b/notebooks/xgboost_diabetes_classification.ipynb
@@ -70,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model_directory = os.path.join(os.getcwd(), \"XGboostModels\")\n",
+    "model_directory = os.path.join(os.getcwd(), \"XGBoostModels\")\n",
     "if not os.path.isdir(model_directory):\n",
     "    os.mkdir(model_directory)\n",
     "\n",


### PR DESCRIPTION
I fixed the typo in the directory where to save the model, as it's causing issue while executing other cells because file doesn't exist.