### PR TITLE
Error Handling Around Scan

### DIFF
--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -122,10 +122,24 @@ class ModelScan:
         scanned = False
         for scan_class in self._scanners_to_run:
             scanner = scan_class(self._settings)  # type: ignore[operator]
-            scan_results = scanner.scan(
-                source=source,
-                data=data,
-            )
+
+            try:
+                scan_results = scanner.scan(
+                    source=source,
+                    data=data,
+                )
+            except Exception as e:
+                logger.error(
+                    f"Error encountered from scanner {scanner.full_name()} with path {source}: {e}"
+                )
+                self._errors.append(
+                    ModelScanError(
+                        scanner.full_name(),
+                        ErrorCategories.MODEL_SCAN,
+                        f"Error encountered from scanner {scanner.full_name()}: {e}",
+                        f"{source}",
+                    )
+                )
 
             if scan_results is not None:
                 scanned = True

--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -67,8 +67,11 @@ class NumpyUnsafeOpScan(ScanBase):
         if data:
             results = scan_numpy(data=data, source=source, settings=self._settings)
 
-        with open(source, "rb") as file_io:
-            results = scan_numpy(data=file_io, source=source, settings=self._settings)
+        else:
+            with open(source, "rb") as file_io:
+                results = scan_numpy(
+                    data=file_io, source=source, settings=self._settings
+                )
 
         return self.label_results(results)
 


### PR DESCRIPTION
Puts error handling around the `scanner.scan` call in `modelscan.py` and returns any unexpected errors as a ModelScanError in the results rather than throwing the exception

Also adds an else clause in `NumpyUnsafeOpScan` so picklescanner won't try to run on both data and source (since the file is closed after the first run)