### PR TITLE
Introducing Model object (the first iteration)

### DIFF
--- a/modelscan/middlewares/__init__.py
+++ b/modelscan/middlewares/__init__.py
@@ -1,0 +1,1 @@
+from modelscan.middlewares.format_via_extension import FormatViaExtensionMiddleware

--- a/modelscan/middlewares/format_via_extension.py
+++ b/modelscan/middlewares/format_via_extension.py
@@ -1,0 +1,17 @@
+from .middleware import MiddlewareBase
+from modelscan.model import Model
+from typing import Callable
+
+
+class FormatViaExtensionMiddleware(MiddlewareBase):
+    def __call__(self, model: Model, call_next: Callable[[Model], None]) -> None:
+        extension = model.get_source().suffix
+        formats = [
+            format
+            for format, extensions in self._settings["formats"].items()
+            if extension in extensions
+        ]
+        if len(formats) > 0:
+            model.set_context("formats", model.get_context("formats") or [] + formats)
+
+        call_next(model)

--- a/modelscan/middlewares/middleware.py
+++ b/modelscan/middlewares/middleware.py
@@ -1,0 +1,59 @@
+import abc
+from modelscan.model import Model
+from typing import Callable, Dict, Any, List
+import importlib
+
+
+class MiddlewareImportError(Exception):
+    pass
+
+
+class MiddlewareBase(metaclass=abc.ABCMeta):
+    _settings: Dict[str, Any]
+
+    def __init__(self, settings: Dict[str, Any]):
+        self._settings = settings
+
+    @abc.abstractmethod
+    def __call__(
+        self,
+        model: Model,
+        call_next: Callable[[Model], None],
+    ) -> None:
+        raise NotImplementedError
+
+
+class MiddlewarePipeline:
+    _middlewares: List[MiddlewareBase]
+
+    def __init__(self) -> None:
+        self._middlewares = []
+
+    @staticmethod
+    def from_settings(middleware_settings: Dict[str, Any]) -> "MiddlewarePipeline":
+        pipeline = MiddlewarePipeline()
+
+        for path, params in middleware_settings.items():
+            try:
+                (modulename, classname) = path.rsplit(".", 1)
+                imported_module = importlib.import_module(
+                    name=modulename, package=classname
+                )
+
+                middleware_class: MiddlewareBase = getattr(imported_module, classname)
+                pipeline.add_middleware(middleware_class(params))  # type: ignore
+            except Exception as e:
+                raise MiddlewareImportError(f"Error importing middleware {path}: {e}")
+
+        return pipeline
+
+    def add_middleware(self, middleware: MiddlewareBase) -> "MiddlewarePipeline":
+        self._middlewares.append(middleware)
+        return self
+
+    def run(self, model: Model) -> None:
+        def runner(model: Model, index: int) -> None:
+            if index < len(self._middlewares):
+                self._middlewares[index](model, lambda model: runner(model, index + 1))
+
+        runner(model, 0)

--- a/modelscan/model.py
+++ b/modelscan/model.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import List, Union, Optional, IO, Generator
+from typing import List, Union, Optional, IO, Generator, Dict, Any
 from modelscan.tools.utils import _is_zipfile
 import zipfile
 
@@ -24,12 +24,15 @@ class ModelBadZip(ValueError):
 
 class Model:
     _source: Path
-    _stream: Optional[IO[bytes]] = None
-    _source_file_used: bool = False
+    _stream: Optional[IO[bytes]]
+    _source_file_used: bool
+    _context: Dict[str, Any]
 
     def __init__(self, source: Union[str, Path], stream: Optional[IO[bytes]] = None):
         self._source = Path(source)
         self._stream = stream
+        self._source_file_used = False
+        self._context = {"formats": []}
 
     @staticmethod
     def from_path(path: Path) -> "Model":
@@ -40,6 +43,12 @@ class Model:
             raise ModelIsDir(f"Path {path} is a directory")
 
         return Model(path)
+
+    def set_context(self, key: str, value: Any) -> None:
+        self._context[key] = value
+
+    def get_context(self, key: str) -> Any:
+        return self._context.get(key)
 
     def open(self) -> "Model":
         if self._stream:

--- a/modelscan/model.py
+++ b/modelscan/model.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from typing import List, Union, Optional, IO, Generator
+from modelscan.tools.utils import _is_zipfile
+import zipfile
+from dataclasses import dataclass
+
+
+class ModelPathNotValid(ValueError):
+    pass
+
+
+class ModelBadZip(ValueError):
+    def __init__(self, e: zipfile.BadZipFile, source: str):
+        self.source = source
+        super().__init__(f"Bad Zip File: {e}")
+
+
+@dataclass
+class Model:
+    source: Union[str, Path]
+    data: Optional[IO[bytes]] = None
+
+    @staticmethod
+    def from_path(path: Path) -> "Model":
+        if not Path.exists(path):
+            raise ModelPathNotValid(f"Path {path} does not exist")
+
+        return Model(path)
+
+    def get_files(self) -> Generator["Model", None, None]:
+        if Path.is_dir(self.source):
+            for f in Path(self.source).rglob("*"):
+                if Path.is_file(f):
+                    yield Model(f)
+
+    def get_zip_files(
+        self, supported_extensions: List[str]
+    ) -> Generator["Model", None, None]:
+        if (
+            not _is_zipfile(self.source)
+            or Path(self.source).suffix not in supported_extensions
+        ):
+            return
+
+        try:
+            with zipfile.ZipFile(self.source, "r") as zip:
+                file_names = zip.namelist()
+                for file_name in file_names:
+                    with zip.open(file_name, "r") as file_io:
+                        yield Model(f"{self.source}:{file_name}", file_io)
+        except zipfile.BadZipFile as e:
+            raise ModelBadZip(e, f"{self.source}:{file_name}")

--- a/modelscan/model.py
+++ b/modelscan/model.py
@@ -1,25 +1,9 @@
 from pathlib import Path
-from typing import List, Union, Optional, IO, Generator, Dict, Any
-from modelscan.tools.utils import _is_zipfile
-import zipfile
-
-
-class ModelPathNotValid(ValueError):
-    pass
+from typing import Union, Optional, IO, Dict, Any
 
 
 class ModelDataEmpty(ValueError):
     pass
-
-
-class ModelIsDir(ValueError):
-    pass
-
-
-class ModelBadZip(ValueError):
-    def __init__(self, e: zipfile.BadZipFile, source: str):
-        self.source = source
-        super().__init__(f"Bad Zip File: {e}")
 
 
 class Model:
@@ -33,16 +17,6 @@ class Model:
         self._stream = stream
         self._source_file_used = False
         self._context = {"formats": []}
-
-    @staticmethod
-    def from_path(path: Path) -> "Model":
-        if not Path.exists(path):
-            raise ModelPathNotValid(f"Path {path} does not exist")
-
-        if Path.is_dir(path):
-            raise ModelIsDir(f"Path {path} is a directory")
-
-        return Model(path)
 
     def set_context(self, key: str, value: Any) -> None:
         self._context[key] = value
@@ -69,26 +43,6 @@ class Model:
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:  # type: ignore
         self.close()
-
-    def get_zip_files(
-        self, supported_extensions: List[str]
-    ) -> Generator["Model", None, None]:
-        if (
-            not _is_zipfile(self._source, data=self._stream)
-            and Path(self._source).suffix not in supported_extensions
-        ):
-            return
-
-        try:
-            with zipfile.ZipFile(
-                self._stream if self._stream else self._source, "r"
-            ) as zip:
-                file_names = zip.namelist()
-                for file_name in file_names:
-                    with zip.open(file_name, "r") as file_io:
-                        yield Model(f"{self._source}:{file_name}", file_io)
-        except zipfile.BadZipFile as e:
-            raise ModelBadZip(e, f"{self._source}:{file_name}")
 
     def get_source(self) -> Path:
         return self._source

--- a/modelscan/model.py
+++ b/modelscan/model.py
@@ -2,10 +2,13 @@ from pathlib import Path
 from typing import List, Union, Optional, IO, Generator
 from modelscan.tools.utils import _is_zipfile
 import zipfile
-from dataclasses import dataclass
 
 
 class ModelPathNotValid(ValueError):
+    pass
+
+
+class ModelDataEmpty(ValueError):
     pass
 
 
@@ -16,12 +19,12 @@ class ModelBadZip(ValueError):
 
 
 class Model:
-    source: Path
-    data: Optional[IO[bytes]] = None
+    _source: Path
+    _data: Optional[IO[bytes]] = None
 
     def __init__(self, source: Union[str, Path], data: Optional[IO[bytes]] = None):
-        self.source = Path(source)
-        self.data = data
+        self._source = Path(source)
+        self._data = data
 
     @staticmethod
     def from_path(path: Path) -> "Model":
@@ -31,8 +34,8 @@ class Model:
         return Model(path)
 
     def get_files(self) -> Generator["Model", None, None]:
-        if Path.is_dir(self.source):
-            for f in Path(self.source).rglob("*"):
+        if Path.is_dir(self._source):
+            for f in Path(self._source).rglob("*"):
                 if Path.is_file(f):
                     yield Model(f)
 
@@ -40,16 +43,28 @@ class Model:
         self, supported_extensions: List[str]
     ) -> Generator["Model", None, None]:
         if (
-            not _is_zipfile(self.source)
-            and Path(self.source).suffix not in supported_extensions
+            not _is_zipfile(self._source)
+            and Path(self._source).suffix not in supported_extensions
         ):
             return
 
         try:
-            with zipfile.ZipFile(self.source, "r") as zip:
+            with zipfile.ZipFile(self._source, "r") as zip:
                 file_names = zip.namelist()
                 for file_name in file_names:
                     with zip.open(file_name, "r") as file_io:
-                        yield Model(f"{self.source}:{file_name}", file_io)
+                        yield Model(f"{self._source}:{file_name}", file_io)
         except zipfile.BadZipFile as e:
-            raise ModelBadZip(e, f"{self.source}:{file_name}")
+            raise ModelBadZip(e, f"{self._source}:{file_name}")
+
+    def get_source(self) -> Path:
+        return self._source
+
+    def has_data(self) -> bool:
+        return self._data is not None
+
+    def get_data(self) -> IO[bytes]:
+        if not self._data:
+            raise ModelDataEmpty("Model data is empty.")
+
+        return self._data

--- a/modelscan/model.py
+++ b/modelscan/model.py
@@ -15,10 +15,13 @@ class ModelBadZip(ValueError):
         super().__init__(f"Bad Zip File: {e}")
 
 
-@dataclass
 class Model:
-    source: Union[str, Path]
+    source: Path
     data: Optional[IO[bytes]] = None
+
+    def __init__(self, source: Union[str, Path], data: Optional[IO[bytes]] = None):
+        self.source = Path(source)
+        self.data = data
 
     @staticmethod
     def from_path(path: Path) -> "Model":
@@ -38,7 +41,7 @@ class Model:
     ) -> Generator["Model", None, None]:
         if (
             not _is_zipfile(self.source)
-            or Path(self.source).suffix not in supported_extensions
+            and Path(self.source).suffix not in supported_extensions
         ):
             return
 

--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -4,7 +4,7 @@ import importlib
 from modelscan.settings import DEFAULT_SETTINGS
 
 from pathlib import Path
-from typing import List, Union, Dict, Any
+from typing import List, Union, Dict, Any, Optional
 from datetime import datetime
 
 from modelscan.error import ModelScanError, ErrorCategories

--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -45,23 +45,6 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
                 [],
             )
 
-        if model.has_data():
-            logger.warning(
-                f"{self.full_name()} got data bytes. It only support direct file scanning."
-            )
-            return ScanResults(
-                [],
-                [],
-                [
-                    ModelScanSkipped(
-                        self.name(),
-                        SkipCategories.H5_DATA,
-                        f"{self.full_name()} got data bytes. It only support direct file scanning.",
-                        str(model.get_source()),
-                    )
-                ],
-            )
-
         results = self._scan_keras_h5_file(model)
         if results:
             return self.label_results(results)
@@ -111,7 +94,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
             )
 
     def _check_model_config(self, model: Model) -> bool:
-        with h5py.File(model.get_source(), "r") as model_hdf5:
+        with h5py.File(model.get_stream(), "r") as model_hdf5:
             if "model_config" in model_hdf5.attrs.keys():
                 return True
             else:
@@ -121,7 +104,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
     def _get_keras_h5_operator_names(self, model: Model) -> Optional[List[Any]]:
         # Todo: source isn't guaranteed to be a file
 
-        with h5py.File(model.get_source(), "r") as model_hdf5:
+        with h5py.File(model.get_stream(), "r") as model_hdf5:
             try:
                 if not "model_config" in model_hdf5.attrs.keys():
                     return None

--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -24,13 +24,9 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if (
-            not model.get_source().suffix
-            in self._settings["scanners"][H5LambdaDetectScan.full_name()][
-                "supported_extensions"
-            ]
-        ):
+        if "keras_h5" not in model.get_context("formats"):
             return None
+
         dep_error = self.handle_binary_dependencies()
         if dep_error:
             return ScanResults(

--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -1,7 +1,6 @@
 import json
 import logging
-from pathlib import Path
-from typing import IO, List, Union, Optional, Dict, Any
+from typing import List, Optional, Dict, Any
 
 
 try:
@@ -15,6 +14,7 @@ from modelscan.error import ModelScanError, ErrorCategories
 from modelscan.skip import ModelScanSkipped, SkipCategories
 from modelscan.scanners.scan import ScanResults
 from modelscan.scanners.saved_model.scan import SavedModelLambdaDetectScan
+from modelscan.model import Model
 
 logger = logging.getLogger("modelscan")
 
@@ -22,11 +22,10 @@ logger = logging.getLogger("modelscan")
 class H5LambdaDetectScan(SavedModelLambdaDetectScan):
     def scan(
         self,
-        source: Union[str, Path],
-        data: Optional[IO[bytes]] = None,
+        model: Model,
     ) -> Optional[ScanResults]:
         if (
-            not Path(source).suffix
+            not model.get_source().suffix
             in self._settings["scanners"][H5LambdaDetectScan.full_name()][
                 "supported_extensions"
             ]
@@ -46,7 +45,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
                 [],
             )
 
-        if data:
+        if model.has_data():
             logger.warning(
                 f"{self.full_name()} got data bytes. It only support direct file scanning."
             )
@@ -58,21 +57,21 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
                         self.name(),
                         SkipCategories.H5_DATA,
                         f"{self.full_name()} got data bytes. It only support direct file scanning.",
-                        str(source),
+                        str(model.get_source()),
                     )
                 ],
             )
 
-        results = self._scan_keras_h5_file(source)
+        results = self._scan_keras_h5_file(model)
         if results:
             return self.label_results(results)
-        else:
-            return None
 
-    def _scan_keras_h5_file(self, source: Union[str, Path]) -> Optional[ScanResults]:
+        return None
+
+    def _scan_keras_h5_file(self, model: Model) -> Optional[ScanResults]:
         machine_learning_library_name = "Keras"
-        if self._check_model_config(source):
-            operators_in_model = self._get_keras_h5_operator_names(source)
+        if self._check_model_config(model):
+            operators_in_model = self._get_keras_h5_operator_names(model)
             if operators_in_model is None:
                 return None
 
@@ -84,7 +83,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
                             self.name(),
                             ErrorCategories.JSON_DECODE,
                             f"Not a valid JSON data",
-                            str(source),
+                            str(model.get_source()),
                         )
                     ],
                     [],
@@ -92,7 +91,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
             return H5LambdaDetectScan._check_for_unsafe_tf_keras_operator(
                 module_name=machine_learning_library_name,
                 raw_operator=operators_in_model,
-                source=source,
+                model=model,
                 unsafe_operators=self._settings["scanners"][
                     SavedModelLambdaDetectScan.full_name()
                 ]["unsafe_keras_operators"],
@@ -106,25 +105,23 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
                         self.name(),
                         SkipCategories.MODEL_CONFIG,
                         f"Model Config not found",
-                        str(source),
+                        str(model.get_source()),
                     )
                 ],
             )
 
-    def _check_model_config(self, source: Union[str, Path]) -> bool:
-        with h5py.File(source, "r") as model_hdf5:
+    def _check_model_config(self, model: Model) -> bool:
+        with h5py.File(model.get_source(), "r") as model_hdf5:
             if "model_config" in model_hdf5.attrs.keys():
                 return True
             else:
-                logger.error(f"Model Config not found in: {source}")
+                logger.error(f"Model Config not found in: {model.get_source()}")
                 return False
 
-    def _get_keras_h5_operator_names(
-        self, source: Union[str, Path]
-    ) -> Optional[List[Any]]:
+    def _get_keras_h5_operator_names(self, model: Model) -> Optional[List[Any]]:
         # Todo: source isn't guaranteed to be a file
 
-        with h5py.File(source, "r") as model_hdf5:
+        with h5py.File(model.get_source(), "r") as model_hdf5:
             try:
                 if not "model_config" in model_hdf5.attrs.keys():
                     return None
@@ -138,7 +135,9 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
                             layer.get("config", {}).get("function", {})
                         )
             except json.JSONDecodeError as e:
-                logger.error(f"Not a valid JSON data from source: {source}, error: {e}")
+                logger.error(
+                    f"Not a valid JSON data from source: {model.get_source()}, error: {e}"
+                )
                 return ["JSONDecodeError"]
 
         if lambda_layers:

--- a/modelscan/scanners/keras/scan.py
+++ b/modelscan/scanners/keras/scan.py
@@ -40,10 +40,7 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
             )
 
         try:
-            source = model.get_source()
-            if model.has_data():
-                source = model.get_data()  # type: ignore
-            with zipfile.ZipFile(source, "r") as zip:
+            with zipfile.ZipFile(model.get_stream(), "r") as zip:
                 file_names = zip.namelist()
                 for file_name in file_names:
                     if file_name == "config.json":
@@ -121,7 +118,7 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
 
     def _get_keras_operator_names(self, model: Model) -> List[str]:
         try:
-            model_config_data = json.load(model.get_data())
+            model_config_data = json.load(model.get_stream())
 
             lambda_layers = [
                 layer.get("config", {}).get("function", {})

--- a/modelscan/scanners/keras/scan.py
+++ b/modelscan/scanners/keras/scan.py
@@ -17,12 +17,7 @@ logger = logging.getLogger("modelscan")
 
 class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
     def scan(self, model: Model) -> Optional[ScanResults]:
-        if (
-            not model.get_source().suffix
-            in self._settings["scanners"][KerasLambdaDetectScan.full_name()][
-                "supported_extensions"
-            ]
-        ):
+        if "keras" not in model.get_context("formats"):
             return None
 
         dep_error = self.handle_binary_dependencies()

--- a/modelscan/scanners/keras/scan.py
+++ b/modelscan/scanners/keras/scan.py
@@ -2,26 +2,23 @@ import json
 import zipfile
 import logging
 from pathlib import Path
-from typing import IO, List, Union, Optional, Any
+from typing import IO, List, Union, Optional
 
 
 from modelscan.error import ModelScanError, ErrorCategories
 from modelscan.skip import ModelScanSkipped, SkipCategories
 from modelscan.scanners.scan import ScanResults
 from modelscan.scanners.saved_model.scan import SavedModelLambdaDetectScan
+from modelscan.model import Model
 
 
 logger = logging.getLogger("modelscan")
 
 
 class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
-    def scan(
-        self,
-        source: Union[str, Path],
-        data: Optional[IO[bytes]] = None,
-    ) -> Optional[ScanResults]:
+    def scan(self, model: Model) -> Optional[ScanResults]:
         if (
-            not Path(source).suffix
+            not model.get_source().suffix
             in self._settings["scanners"][KerasLambdaDetectScan.full_name()][
                 "supported_extensions"
             ]
@@ -43,16 +40,19 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
             )
 
         try:
-            with zipfile.ZipFile(data or source, "r") as zip:
+            source = model.get_source()
+            if model.has_data():
+                source = model.get_data()  # type: ignore
+            with zipfile.ZipFile(source, "r") as zip:
                 file_names = zip.namelist()
                 for file_name in file_names:
                     if file_name == "config.json":
                         with zip.open(file_name, "r") as config_file:
+                            model = Model(
+                                f"{model.get_source()}:{file_name}", config_file
+                            )
                             return self.label_results(
-                                self._scan_keras_config_file(
-                                    source=f"{source}:{file_name}",
-                                    config_file=config_file,
-                                )
+                                self._scan_keras_config_file(model)
                             )
         except zipfile.BadZipFile as e:
             return ScanResults(
@@ -63,7 +63,7 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
                         self.name(),
                         SkipCategories.BAD_ZIP,
                         f"Skipping zip file due to error: {e}",
-                        f"{source}:{file_name}",
+                        f"{model.get_source()}:{file_name}",
                     )
                 ],
             )
@@ -76,20 +76,18 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
                     self.name(),
                     ErrorCategories.MODEL_SCAN,  # Giving a generic error category as this return is added to pass mypy
                     f"Unable to scan .keras file",  # Not sure if this is a representative message for ModelScanError
-                    str(source),
+                    str(model.get_source()),
                 )
             ],
             [],
         )
 
-    def _scan_keras_config_file(
-        self, source: Union[str, Path], config_file: IO[bytes]
-    ) -> ScanResults:
+    def _scan_keras_config_file(self, model: Model) -> ScanResults:
         machine_learning_library_name = "Keras"
 
         # if self._check_json_data(source, config_file):
 
-        operators_in_model = self._get_keras_operator_names(source, config_file)
+        operators_in_model = self._get_keras_operator_names(model)
         if operators_in_model:
             if "JSONDecodeError" in operators_in_model:
                 return ScanResults(
@@ -99,7 +97,7 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
                             self.name(),
                             ErrorCategories.JSON_DECODE,
                             f"Not a valid JSON data",
-                            str(source),
+                            str(model.get_source()),
                         )
                     ],
                     [],
@@ -108,7 +106,7 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
             return KerasLambdaDetectScan._check_for_unsafe_tf_keras_operator(
                 module_name=machine_learning_library_name,
                 raw_operator=operators_in_model,
-                source=source,
+                model=model,
                 unsafe_operators=self._settings["scanners"][
                     SavedModelLambdaDetectScan.full_name()
                 ]["unsafe_keras_operators"],
@@ -121,11 +119,9 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
                 [],
             )
 
-    def _get_keras_operator_names(
-        self, source: Union[str, Path], data: IO[bytes]
-    ) -> List[str]:
+    def _get_keras_operator_names(self, model: Model) -> List[str]:
         try:
-            model_config_data = json.load(data)
+            model_config_data = json.load(model.get_data())
 
             lambda_layers = [
                 layer.get("config", {}).get("function", {})
@@ -136,7 +132,9 @@ class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
                 return ["Lambda"] * len(lambda_layers)
 
         except json.JSONDecodeError as e:
-            logger.error(f"Not a valid JSON data from source: {source}, error: {e}")
+            logger.error(
+                f"Not a valid JSON data from source: {model.get_source()}, error: {e}"
+            )
             return ["JSONDecodeError"]
 
         return []

--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -26,22 +26,13 @@ class PyTorchUnsafeOpScan(ScanBase):
         ):
             return None
 
-        if _is_zipfile(
-            model.get_source(), model.get_data() if model.has_data() else None
-        ):
+        if _is_zipfile(model.get_source(), model.get_stream()):
             return None
 
-        if model.has_data():
-            results = scan_pytorch(
-                model=model,
-                settings=self._settings,
-            )
-
-            return self.label_results(results)
-
-        with open(model.get_source(), "rb") as file_io:
-            model = Model(model.get_source(), file_io)
-            results = scan_pytorch(model=model, settings=self._settings)
+        results = scan_pytorch(
+            model=model,
+            settings=self._settings,
+        )
 
         return self.label_results(results)
 
@@ -67,17 +58,10 @@ class NumpyUnsafeOpScan(ScanBase):
         ):
             return None
 
-        if model.has_data():
-            results = scan_numpy(
-                model=model,
-                settings=self._settings,
-            )
-
-            return self.label_results(results)
-
-        with open(model.get_source(), "rb") as file_io:
-            model = Model(model.get_source(), file_io)
-            results = scan_numpy(model=model, settings=self._settings)
+        results = scan_numpy(
+            model=model,
+            settings=self._settings,
+        )
 
         return self.label_results(results)
 
@@ -103,17 +87,10 @@ class PickleUnsafeOpScan(ScanBase):
         ):
             return None
 
-        if model.has_data():
-            results = scan_pickle_bytes(
-                model=model,
-                settings=self._settings,
-            )
-
-            return self.label_results(results)
-
-        with open(model.get_source(), "rb") as file_io:
-            model = Model(model.get_source(), file_io)
-            results = scan_pickle_bytes(model=model, settings=self._settings)
+        results = scan_pickle_bytes(
+            model=model,
+            settings=self._settings,
+        )
 
         return self.label_results(results)
 

--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -18,12 +18,7 @@ class PyTorchUnsafeOpScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if (
-            not model.get_source().suffix
-            in self._settings["scanners"][PyTorchUnsafeOpScan.full_name()][
-                "supported_extensions"
-            ]
-        ):
+        if "pytorch" not in model.get_context("formats"):
             return None
 
         if _is_zipfile(model.get_source(), model.get_stream()):
@@ -50,12 +45,7 @@ class NumpyUnsafeOpScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if (
-            not model.get_source().suffix
-            in self._settings["scanners"][NumpyUnsafeOpScan.full_name()][
-                "supported_extensions"
-            ]
-        ):
+        if "numpy" not in model.get_context("formats"):
             return None
 
         results = scan_numpy(
@@ -79,12 +69,7 @@ class PickleUnsafeOpScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if (
-            not model.get_source().suffix
-            in self._settings["scanners"][PickleUnsafeOpScan.full_name()][
-                "supported_extensions"
-            ]
-        ):
+        if "pickle" not in model.get_context("formats"):
             return None
 
         results = scan_pickle_bytes(

--- a/modelscan/scanners/saved_model/scan.py
+++ b/modelscan/scanners/saved_model/scan.py
@@ -29,10 +29,7 @@ class SavedModelScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if (
-            not model.get_source().suffix
-            in self._settings["scanners"][self.full_name()]["supported_extensions"]
-        ):
+        if "tf_saved_model" not in model.get_context("formats"):
             return None
 
         dep_error = self.handle_binary_dependencies()

--- a/modelscan/scanners/saved_model/scan.py
+++ b/modelscan/scanners/saved_model/scan.py
@@ -49,14 +49,7 @@ class SavedModelScan(ScanBase):
                 [],
             )
 
-        if model.has_data():
-            results = self._scan(model)
-
-            return self.label_results(results) if results else None
-
-        with open(model.get_source(), "rb") as file_io:
-            model = Model(model.get_source(), file_io)
-            results = self._scan(model)
+        results = self._scan(model)
 
         return self.label_results(results) if results else None
 
@@ -148,7 +141,7 @@ class SavedModelLambdaDetectScan(SavedModelScan):
     @staticmethod
     def _get_keras_pb_operator_names(model: Model) -> List[str]:
         saved_metadata = SavedMetadata()
-        saved_metadata.ParseFromString(model.get_data().read())
+        saved_metadata.ParseFromString(model.get_stream().read())
 
         try:
             lambda_layers = [
@@ -194,7 +187,7 @@ class SavedModelTensorflowOpScan(SavedModelScan):
 
     def _get_tensorflow_operator_names(self, model: Model) -> List[str]:
         saved_model = SavedModel()
-        saved_model.ParseFromString(model.get_data().read())
+        saved_model.ParseFromString(model.get_stream().read())
 
         model_op_names: Set[str] = set()
         # Iterate over every metagraph in case there is more than one

--- a/modelscan/scanners/saved_model/scan.py
+++ b/modelscan/scanners/saved_model/scan.py
@@ -19,6 +19,7 @@ except ImportError:
 from modelscan.error import ModelScanError, ErrorCategories
 from modelscan.issues import Issue, IssueCode, IssueSeverity, OperatorIssueDetails
 from modelscan.scanners.scan import ScanBase, ScanResults
+from modelscan.model import Model
 
 logger = logging.getLogger("modelscan")
 
@@ -26,11 +27,10 @@ logger = logging.getLogger("modelscan")
 class SavedModelScan(ScanBase):
     def scan(
         self,
-        source: Union[str, Path],
-        data: Optional[IO[bytes]] = None,
+        model: Model,
     ) -> Optional[ScanResults]:
         if (
-            not Path(source).suffix
+            not model.get_source().suffix
             in self._settings["scanners"][self.full_name()]["supported_extensions"]
         ):
             return None
@@ -49,19 +49,18 @@ class SavedModelScan(ScanBase):
                 [],
             )
 
-        if data:
-            results = self._scan(source, data)
+        if model.has_data():
+            results = self._scan(model)
 
-        else:
-            with open(source, "rb") as file_io:
-                results = self._scan(source, data=file_io)
+            return self.label_results(results) if results else None
 
-        if results:
-            return self.label_results(results)
-        else:
-            return None
+        with open(model.get_source(), "rb") as file_io:
+            model = Model(model.get_source(), file_io)
+            results = self._scan(model)
 
-    def _scan(self, source: Union[str, Path], data: IO[bytes]) -> Optional[ScanResults]:
+        return self.label_results(results) if results else None
+
+    def _scan(self, model: Model) -> Optional[ScanResults]:
         raise NotImplementedError
 
     # This function checks for malicious operators in both Keras and Tensorflow
@@ -69,7 +68,7 @@ class SavedModelScan(ScanBase):
     def _check_for_unsafe_tf_keras_operator(
         module_name: str,
         raw_operator: List[str],
-        source: Union[str, Path],
+        model: Model,
         unsafe_operators: Dict[str, Any],
     ) -> ScanResults:
         issues: List[Issue] = []
@@ -93,7 +92,7 @@ class SavedModelScan(ScanBase):
                     details=OperatorIssueDetails(
                         module=module_name,
                         operator=op,
-                        source=source,
+                        source=str(model.get_source()),
                         severity=severity,
                     ),
                 )
@@ -117,44 +116,39 @@ class SavedModelScan(ScanBase):
 
 
 class SavedModelLambdaDetectScan(SavedModelScan):
-    def _scan(self, source: Union[str, Path], data: IO[bytes]) -> Optional[ScanResults]:
-        file_name = str(source).split("/")[-1]
-        if file_name == "keras_metadata.pb":
-            machine_learning_library_name = "Keras"
-            operators_in_model = self._get_keras_pb_operator_names(
-                data=data, source=source
-            )
-            if operators_in_model:
-                if "JSONDecodeError" in operators_in_model:
-                    return ScanResults(
-                        [],
-                        [
-                            ModelScanError(
-                                self.name(),
-                                ErrorCategories.JSON_DECODE,
-                                f"Not a valid JSON data",
-                                str(source),
-                            )
-                        ],
-                        [],
-                    )
-
-            return SavedModelScan._check_for_unsafe_tf_keras_operator(
-                machine_learning_library_name,
-                operators_in_model,
-                source,
-                self._settings["scanners"][self.full_name()]["unsafe_keras_operators"],
-            )
-
-        else:
+    def _scan(self, model: Model) -> Optional[ScanResults]:
+        file_name = str(model.get_source()).split("/")[-1]
+        if file_name != "keras_metadata.pb":
             return None
 
+        machine_learning_library_name = "Keras"
+        operators_in_model = self._get_keras_pb_operator_names(model)
+        if operators_in_model:
+            if "JSONDecodeError" in operators_in_model:
+                return ScanResults(
+                    [],
+                    [
+                        ModelScanError(
+                            self.name(),
+                            ErrorCategories.JSON_DECODE,
+                            f"Not a valid JSON data",
+                            str(model.get_source()),
+                        )
+                    ],
+                    [],
+                )
+
+        return SavedModelScan._check_for_unsafe_tf_keras_operator(
+            machine_learning_library_name,
+            operators_in_model,
+            model,
+            self._settings["scanners"][self.full_name()]["unsafe_keras_operators"],
+        )
+
     @staticmethod
-    def _get_keras_pb_operator_names(
-        data: IO[bytes], source: Union[str, Path]
-    ) -> List[str]:
+    def _get_keras_pb_operator_names(model: Model) -> List[str]:
         saved_metadata = SavedMetadata()
-        saved_metadata.ParseFromString(data.read())
+        saved_metadata.ParseFromString(model.get_data().read())
 
         try:
             lambda_layers = [
@@ -170,7 +164,9 @@ class SavedModelLambdaDetectScan(SavedModelScan):
                 return ["Lambda"] * len(lambda_layers)
 
         except json.JSONDecodeError as e:
-            logger.error(f"Not a valid JSON data from source: {source}, error: {e}")
+            logger.error(
+                f"Not a valid JSON data from source: {str(model.get_source())}, error: {e}"
+            )
             return ["JSONDecodeError"]
 
         return []
@@ -181,25 +177,24 @@ class SavedModelLambdaDetectScan(SavedModelScan):
 
 
 class SavedModelTensorflowOpScan(SavedModelScan):
-    def _scan(self, source: Union[str, Path], data: IO[bytes]) -> Optional[ScanResults]:
-        file_name = str(source).split("/")[-1]
+    def _scan(self, model: Model) -> Optional[ScanResults]:
+        file_name = str(model.get_source()).split("/")[-1]
         if file_name == "keras_metadata.pb":
             return None
 
-        else:
-            machine_learning_library_name = "Tensorflow"
-            operators_in_model = self._get_tensorflow_operator_names(data=data)
+        machine_learning_library_name = "Tensorflow"
+        operators_in_model = self._get_tensorflow_operator_names(model)
 
         return SavedModelScan._check_for_unsafe_tf_keras_operator(
             machine_learning_library_name,
             operators_in_model,
-            source,
+            model,
             self._settings["scanners"][self.full_name()]["unsafe_tf_operators"],
         )
 
-    def _get_tensorflow_operator_names(self, data: IO[bytes]) -> List[str]:
+    def _get_tensorflow_operator_names(self, model: Model) -> List[str]:
         saved_model = SavedModel()
-        saved_model.ParseFromString(data.read())
+        saved_model.ParseFromString(model.get_data().read())
 
         model_op_names: Set[str] = set()
         # Iterate over every metagraph in case there is more than one

--- a/modelscan/scanners/scan.py
+++ b/modelscan/scanners/scan.py
@@ -1,10 +1,10 @@
 import abc
-from pathlib import Path
-from typing import List, Union, Optional, IO, Any, Dict
+from typing import List, Optional, Any, Dict
 
 from modelscan.error import ModelScanError
 from modelscan.skip import ModelScanSkipped
 from modelscan.issues import Issue
+from modelscan.model import Model
 
 
 class ScanResults:
@@ -43,8 +43,7 @@ class ScanBase(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def scan(
         self,
-        source: Union[str, Path],
-        data: Optional[IO[bytes]] = None,
+        model: Model,
     ) -> Optional[ScanResults]:
         raise NotImplementedError
 

--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -15,22 +15,18 @@ DEFAULT_SETTINGS = {
     "scanners": {
         "modelscan.scanners.H5LambdaDetectScan": {
             "enabled": True,
-            "supported_extensions": [".h5"],
         },
         "modelscan.scanners.KerasLambdaDetectScan": {
             "enabled": True,
-            "supported_extensions": [".keras"],
         },
         "modelscan.scanners.SavedModelLambdaDetectScan": {
             "enabled": True,
-            "supported_extensions": [".pb"],
             "unsafe_keras_operators": {
                 "Lambda": "MEDIUM",
             },
         },
         "modelscan.scanners.SavedModelTensorflowOpScan": {
             "enabled": True,
-            "supported_extensions": [".pb"],
             "unsafe_tf_operators": {
                 "ReadFile": "HIGH",
                 "WriteFile": "HIGH",
@@ -38,23 +34,33 @@ DEFAULT_SETTINGS = {
         },
         "modelscan.scanners.NumpyUnsafeOpScan": {
             "enabled": True,
-            "supported_extensions": [".npy"],
         },
         "modelscan.scanners.PickleUnsafeOpScan": {
             "enabled": True,
-            "supported_extensions": [
-                ".pkl",
-                ".pickle",
-                ".joblib",
-                ".dill",
-                ".dat",
-                ".data",
-            ],
         },
         "modelscan.scanners.PyTorchUnsafeOpScan": {
             "enabled": True,
-            "supported_extensions": [".bin", ".pt", ".pth", ".ckpt"],
         },
+    },
+    "middlewares": {
+        "modelscan.middlewares.FormatViaExtensionMiddleware": {
+            "formats": {
+                "tf": [".pb"],
+                "tf_saved_model": [".pb"],
+                "keras_h5": [".h5"],
+                "keras": [".keras"],
+                "numpy": [".npy"],
+                "pytorch": [".bin", ".pt", ".pth", ".ckpt"],
+                "pickle": [
+                    ".pkl",
+                    ".pickle",
+                    ".joblib",
+                    ".dill",
+                    ".dat",
+                    ".data",
+                ],
+            }
+        }
     },
     "unsafe_globals": {
         "CRITICAL": {

--- a/modelscan/tools/picklescanner.py
+++ b/modelscan/tools/picklescanner.py
@@ -1,7 +1,5 @@
 import logging
 import pickletools  # nosec
-from dataclasses import dataclass
-from pathlib import Path
 from tarfile import TarError
 from typing import IO, Any, Dict, List, Set, Tuple, Union
 
@@ -11,6 +9,7 @@ from modelscan.error import ModelScanError, ErrorCategories
 from modelscan.skip import ModelScanSkipped, SkipCategories
 from modelscan.issues import Issue, IssueCode, IssueSeverity, OperatorIssueDetails
 from modelscan.scanners.scan import ScanResults
+from modelscan.model import Model
 
 logger = logging.getLogger("modelscan")
 
@@ -117,17 +116,15 @@ def _list_globals(
 
 
 def scan_pickle_bytes(
-    data: IO[bytes],
-    source: Union[Path, str],
+    model: Model,
     settings: Dict[str, Any],
     scan_name: str = "pickle",
     multiple_pickles: bool = True,
 ) -> ScanResults:
     """Disassemble a Pickle stream and report issues"""
-
     issues: List[Issue] = []
     try:
-        raw_globals = _list_globals(data, multiple_pickles)
+        raw_globals = _list_globals(model.get_data(), multiple_pickles)
     except GenOpsError as e:
         return ScanResults(
             issues,
@@ -136,13 +133,13 @@ def scan_pickle_bytes(
                     scan_name,
                     ErrorCategories.PICKLE_GENOPS,
                     f"Parsing error: {e}",
-                    str(source),
+                    str(model.get_source()),
                 )
             ],
             [],
         )
 
-    logger.debug("Global imports in %s: %s", source, raw_globals)
+    logger.debug("Global imports in %s: %s", model.get_source(), raw_globals)
     severities = {
         "CRITICAL": IssueSeverity.CRITICAL,
         "HIGH": IssueSeverity.HIGH,
@@ -176,7 +173,7 @@ def scan_pickle_bytes(
                     details=OperatorIssueDetails(
                         module=global_module,
                         operator=global_name,
-                        source=source,
+                        source=model.get_source(),
                         severity=severity,
                     ),
                 )
@@ -184,18 +181,16 @@ def scan_pickle_bytes(
     return ScanResults(issues, [], [])
 
 
-def scan_numpy(
-    data: IO[bytes], source: Union[str, Path], settings: Dict[str, Any]
-) -> ScanResults:
+def scan_numpy(model: Model, settings: Dict[str, Any]) -> ScanResults:
     scan_name = "numpy"
     # Code to distinguish from NumPy binary files and pickles.
     _ZIP_PREFIX = b"PK\x03\x04"
     _ZIP_SUFFIX = b"PK\x05\x06"  # empty zip files start with this
     N = len(np.lib.format.MAGIC_PREFIX)
-    magic = data.read(N)
+    magic = model.get_data().read(N)
     # If the file size is less than N, we need to make sure not
     # to seek past the beginning of the file
-    data.seek(-min(N, len(magic)), 1)  # back-up
+    model.get_data().seek(-min(N, len(magic)), 1)  # back-up
     if magic.startswith(_ZIP_PREFIX) or magic.startswith(_ZIP_SUFFIX):
         # .npz file
         return ScanResults(
@@ -206,40 +201,38 @@ def scan_numpy(
                     scan_name,
                     SkipCategories.NOT_IMPLEMENTED,
                     "Scanning of .npz files is not implemented yet",
-                    str(source),
+                    str(model.get_source()),
                 )
             ],
         )
 
     elif magic == np.lib.format.MAGIC_PREFIX:
         # .npy file
-        version = np.lib.format.read_magic(data)  # type: ignore[no-untyped-call]
+        version = np.lib.format.read_magic(model.get_data())  # type: ignore[no-untyped-call]
         np.lib.format._check_version(version)  # type: ignore[attr-defined]
-        _, _, dtype = np.lib.format._read_array_header(data, version)  # type: ignore[attr-defined]
+        _, _, dtype = np.lib.format._read_array_header(model.get_data(), version)  # type: ignore[attr-defined]
 
         if dtype.hasobject:
-            return scan_pickle_bytes(data, source, settings, scan_name)
+            return scan_pickle_bytes(model, settings, scan_name)
         else:
             return ScanResults([], [], [])
     else:
-        return scan_pickle_bytes(data, source, settings, scan_name)
+        return scan_pickle_bytes(model, settings, scan_name)
 
 
-def scan_pytorch(
-    data: IO[bytes], source: Union[str, Path], settings: Dict[str, Any]
-) -> ScanResults:
+def scan_pytorch(model: Model, settings: Dict[str, Any]) -> ScanResults:
     scan_name = "pytorch"
-    should_read_directly = _should_read_directly(data)
-    if should_read_directly and data.tell() == 0:
+    should_read_directly = _should_read_directly(model.get_data())
+    if should_read_directly and model.get_data().tell() == 0:
         # try loading from tar
         try:
             # TODO: implement loading from tar
             raise TarError()
         except TarError:
             # file does not contain a tar
-            data.seek(0)
+            model.get_data().seek(0)
 
-    magic = get_magic_number(data)
+    magic = get_magic_number(model.get_data())
     if magic != MAGIC_NUMBER:
         return ScanResults(
             [],
@@ -249,8 +242,9 @@ def scan_pytorch(
                     scan_name,
                     SkipCategories.MAGIC_NUMBER,
                     f"Invalid magic number",
-                    str(source),
+                    str(model.get_source()),
                 )
             ],
         )
-    return scan_pickle_bytes(data, source, settings, scan_name, multiple_pickles=False)
+
+    return scan_pickle_bytes(model, settings, scan_name, multiple_pickles=False)

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -34,11 +34,11 @@ from modelscan.issues import (
 )
 from modelscan.tools.picklescanner import (
     scan_pickle_bytes,
-    scan_numpy,
 )
 
 from modelscan.skip import SkipCategories
 from modelscan.settings import DEFAULT_SETTINGS
+from modelscan.model import Model
 
 settings: Dict[str, Any] = DEFAULT_SETTINGS
 
@@ -431,12 +431,8 @@ def test_scan_pickle_bytes() -> None:
         )
     ]
 
-    assert (
-        scan_pickle_bytes(
-            io.BytesIO(pickle.dumps(Malicious1())), "file.pkl", settings
-        ).issues
-        == expected
-    )
+    model = Model("file.pkl", io.BytesIO(pickle.dumps(Malicious1())))
+    assert scan_pickle_bytes(model, settings).issues == expected
 
 
 def test_scan_zip(zip_file_path: Any) -> None:

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -452,7 +452,10 @@ def test_scan_zip(zip_file_path: Any) -> None:
     ms = ModelScan()
     results = ms.scan(f"{zip_file_path}/test.zip")
     assert results["summary"]["scanned"]["scanned_files"] == [f"test.zip:data.pkl"]
-    assert results["summary"]["skipped"]["skipped_files"] == []
+    assert [
+        skipped_file["source"]
+        for skipped_file in results["summary"]["skipped"]["skipped_files"]
+    ] == ["test.zip"]
     assert ms.issues.all_issues == expected
 
 
@@ -474,14 +477,17 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
         f"safe_zip_pytorch.pt:safe_zip_pytorch/data.pkl"
     ]
 
-    assert [
-        skipped_file["source"]
-        for skipped_file in results["summary"]["skipped"]["skipped_files"]
-    ] == [
+    assert set(
+        [
+            skipped_file["source"]
+            for skipped_file in results["summary"]["skipped"]["skipped_files"]
+        ]
+    ) == {
+        "safe_zip_pytorch.pt",
         "safe_zip_pytorch.pt:safe_zip_pytorch/byteorder",
         "safe_zip_pytorch.pt:safe_zip_pytorch/version",
         "safe_zip_pytorch.pt:safe_zip_pytorch/.data/serialization_id",
-    ]
+    }
     assert ms.issues.all_issues == []
     assert results["errors"] == []
 
@@ -510,14 +516,17 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
     assert results["summary"]["scanned"]["scanned_files"] == [
         f"unsafe_zip_pytorch.pt:unsafe_zip_pytorch/data.pkl",
     ]
-    assert [
-        skipped_file["source"]
-        for skipped_file in results["summary"]["skipped"]["skipped_files"]
-    ] == [
+    assert set(
+        [
+            skipped_file["source"]
+            for skipped_file in results["summary"]["skipped"]["skipped_files"]
+        ]
+    ) == {
+        "unsafe_zip_pytorch.pt",
         "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/byteorder",
         "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/version",
         "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/.data/serialization_id",
-    ]
+    }
     assert ms.issues.all_issues == expected
     assert results["errors"] == []
 
@@ -1235,7 +1244,10 @@ def test_scan_directory_path(file_path: str) -> None:
         f"benign0_v3.dill",
         f"benign0_v4.dill",
     }
-    assert results["summary"]["skipped"]["skipped_files"] == []
+    assert [
+        skipped_file["source"]
+        for skipped_file in results["summary"]["skipped"]["skipped_files"]
+    ] == ["malicious1.zip"]
     assert results["errors"] == []
 
 

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -483,7 +483,6 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
             for skipped_file in results["summary"]["skipped"]["skipped_files"]
         ]
     ) == {
-        "safe_zip_pytorch.pt",
         "safe_zip_pytorch.pt:safe_zip_pytorch/byteorder",
         "safe_zip_pytorch.pt:safe_zip_pytorch/version",
         "safe_zip_pytorch.pt:safe_zip_pytorch/.data/serialization_id",
@@ -522,7 +521,6 @@ def test_scan_pytorch(pytorch_file_path: Any) -> None:
             for skipped_file in results["summary"]["skipped"]["skipped_files"]
         ]
     ) == {
-        "unsafe_zip_pytorch.pt",
         "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/byteorder",
         "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/version",
         "unsafe_zip_pytorch.pt:unsafe_zip_pytorch/.data/serialization_id",
@@ -1295,19 +1293,7 @@ def test_scan_keras(keras_file_path: Any, file_extension: str) -> None:
             f"safe{file_extension}"
         ]
 
-        if file_extension == ".keras":
-            assert set(
-                [
-                    skipped_file["source"]
-                    for skipped_file in results["summary"]["skipped"]["skipped_files"]
-                ]
-            ) == {
-                f"safe{file_extension}:metadata.json",
-                f"safe{file_extension}:config.json",
-                f"safe{file_extension}:model.weights.h5",
-            }
-        else:
-            assert results["summary"]["skipped"]["skipped_files"] == []
+        assert results["summary"]["skipped"]["skipped_files"] == []
 
         assert results["errors"] == []
 


### PR DESCRIPTION
## Description

This is the first iteration of introducing `Model` object that will be used by each scanner instead of relying on `data` and `source`. That way, we could re-use file reading and cache variables and provide context. 

This `Model` uses context manager to open a stream of bytes and pass them to scanners separately instead of relying on scanners to handle it. They still can just scan in a custom way.

As this refactoring might take time, I decided to split it into multiple PRs, and in this PR, I used the same approach but with passing `Model`.