### PR TITLE
Standardize model format names

### DIFF
--- a/modelscan/scanners/h5/scan.py
+++ b/modelscan/scanners/h5/scan.py
@@ -18,6 +18,7 @@ from modelscan.skip import ModelScanSkipped, SkipCategories
 from modelscan.scanners.scan import ScanResults
 from modelscan.scanners.saved_model.scan import SavedModelLambdaDetectScan
 from modelscan.model import Model
+from modelscan.settings import DefaultModelFormats
 
 logger = logging.getLogger("modelscan")
 
@@ -27,7 +28,7 @@ class H5LambdaDetectScan(SavedModelLambdaDetectScan):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if "keras_h5" not in model.get_context("formats"):
+        if DefaultModelFormats.KERAS_H5 not in model.get_context("formats"):
             return None
 
         dep_error = self.handle_binary_dependencies()

--- a/modelscan/scanners/keras/scan.py
+++ b/modelscan/scanners/keras/scan.py
@@ -9,6 +9,7 @@ from modelscan.skip import ModelScanSkipped, SkipCategories
 from modelscan.scanners.scan import ScanResults
 from modelscan.scanners.saved_model.scan import SavedModelLambdaDetectScan
 from modelscan.model import Model
+from modelscan.settings import DefaultModelFormats
 
 
 logger = logging.getLogger("modelscan")
@@ -16,7 +17,7 @@ logger = logging.getLogger("modelscan")
 
 class KerasLambdaDetectScan(SavedModelLambdaDetectScan):
     def scan(self, model: Model) -> Optional[ScanResults]:
-        if "keras" not in model.get_context("formats"):
+        if DefaultModelFormats.KERAS not in model.get_context("formats"):
             return None
 
         dep_error = self.handle_binary_dependencies()

--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -9,6 +9,7 @@ from modelscan.tools.picklescanner import (
     scan_pytorch,
 )
 from modelscan.model import Model
+from modelscan.settings import DefaultModelFormats
 
 logger = logging.getLogger("modelscan")
 
@@ -18,7 +19,7 @@ class PyTorchUnsafeOpScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if "pytorch" not in model.get_context("formats"):
+        if DefaultModelFormats.PYTORCH not in model.get_context("formats"):
             return None
 
         if _is_zipfile(model.get_source(), model.get_stream()):
@@ -45,7 +46,7 @@ class NumpyUnsafeOpScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if "numpy" not in model.get_context("formats"):
+        if DefaultModelFormats.NUMPY not in model.get_context("formats"):
             return None
 
         results = scan_numpy(
@@ -69,7 +70,7 @@ class PickleUnsafeOpScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if "pickle" not in model.get_context("formats"):
+        if DefaultModelFormats.PICKLE not in model.get_context("formats"):
             return None
 
         results = scan_pickle_bytes(

--- a/modelscan/scanners/saved_model/scan.py
+++ b/modelscan/scanners/saved_model/scan.py
@@ -22,6 +22,7 @@ from modelscan.error import (
 from modelscan.issues import Issue, IssueCode, IssueSeverity, OperatorIssueDetails
 from modelscan.scanners.scan import ScanBase, ScanResults
 from modelscan.model import Model
+from modelscan.settings import DefaultModelFormats
 
 logger = logging.getLogger("modelscan")
 
@@ -31,7 +32,7 @@ class SavedModelScan(ScanBase):
         self,
         model: Model,
     ) -> Optional[ScanResults]:
-        if "tf_saved_model" not in model.get_context("formats"):
+        if DefaultModelFormats.TENSORFLOW not in model.get_context("formats"):
             return None
 
         dep_error = self.handle_binary_dependencies()

--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -1,8 +1,19 @@
 import tomlkit
 
+from enum import Enum
 from typing import Any
 
 from modelscan._version import __version__
+
+
+class DefaultModelFormats(Enum):
+    TENSORFLOW = "tensorflow"
+    KERAS_H5 = "keras_h5"
+    KERAS = "keras"
+    NUMPY = "numpy"
+    PYTORCH = "pytorch"
+    PICKLE = "pickle"
+
 
 DEFAULT_REPORTING_MODULES = {
     "console": "modelscan.reports.ConsoleReport",
@@ -59,13 +70,12 @@ DEFAULT_SETTINGS = {
     "middlewares": {
         "modelscan.middlewares.FormatViaExtensionMiddleware": {
             "formats": {
-                "tf": [".pb"],
-                "tf_saved_model": [".pb"],
-                "keras_h5": [".h5"],
-                "keras": [".keras"],
-                "numpy": [".npy"],
-                "pytorch": [".bin", ".pt", ".pth", ".ckpt"],
-                "pickle": [
+                DefaultModelFormats.TENSORFLOW: [".pb"],
+                DefaultModelFormats.KERAS_H5: [".h5"],
+                DefaultModelFormats.KERAS: [".keras"],
+                DefaultModelFormats.NUMPY: [".npy"],
+                DefaultModelFormats.PYTORCH: [".bin", ".pt", ".pth", ".ckpt"],
+                DefaultModelFormats.PICKLE: [
                     ".pkl",
                     ".pickle",
                     ".joblib",


### PR DESCRIPTION
Makes an enum for model format names referenced in each scanner and the extension detector middleware