### PR TITLE
Port picklescan PR #29

### DIFF
--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -125,6 +125,9 @@ DEFAULT_SETTINGS = {
             ],
             "pty": "*",
             "pickle": "*",
+            "bdb": "*",
+            "pdb": "*",
+            "shutil": "*",
         },
         "HIGH": {
             "webbrowser": "*",  # Includes webbrowser.open()

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -1022,6 +1022,16 @@ def test_scan_pickle_operators(file_path: Any) -> None:
                 IssueSeverity.CRITICAL,
                 f"{file_path}/data/malicious15.pkl",
             ),
+        ),
+        Issue(
+            IssueCode.UNSAFE_OPERATOR,
+            IssueSeverity.CRITICAL,
+            OperatorIssueDetails(
+                "bdb",
+                "Bdb.run",
+                IssueSeverity.CRITICAL,
+                f"{file_path}/data/malicious15.pkl",
+            ),
         )
     ]
     malicious15 = ModelScan()

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -1036,7 +1036,7 @@ def test_scan_pickle_operators(file_path: Any) -> None:
     ]
     malicious15 = ModelScan()
     malicious15.scan(Path(f"{file_path}/data/malicious15.pkl"))
-    assert sorted(malicious15.issues.all_issues) == sorted(expected_malicious15)
+    assert sorted(malicious15.issues.all_issues, key=str) == sorted(expected_malicious15, key=str)
 
 
 def test_scan_directory_path(file_path: str) -> None:

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -1036,7 +1036,9 @@ def test_scan_pickle_operators(file_path: Any) -> None:
     ]
     malicious15 = ModelScan()
     malicious15.scan(Path(f"{file_path}/data/malicious15.pkl"))
-    assert sorted(malicious15.issues.all_issues, key=str) == sorted(expected_malicious15, key=str)
+    assert sorted(malicious15.issues.all_issues, key=str) == sorted(
+        expected_malicious15, key=str
+    )
 
 
 def test_scan_directory_path(file_path: str) -> None:

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -90,7 +90,7 @@ class Malicious8:
 
 
 class Malicious15:
-    def __reduce__(self):
+    def __reduce__(self) -> Any:
         bd = bdb.Bdb()
         return bdb.Bdb.run, (
             bd,
@@ -1036,7 +1036,7 @@ def test_scan_pickle_operators(file_path: Any) -> None:
     ]
     malicious15 = ModelScan()
     malicious15.scan(Path(f"{file_path}/data/malicious15.pkl"))
-    assert malicious15.issues.all_issues == expected_malicious15
+    assert sorted(malicious15.issues.all_issues) == sorted(expected_malicious15)
 
 
 def test_scan_directory_path(file_path: str) -> None:

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -1018,7 +1018,7 @@ def test_scan_pickle_operators(file_path: Any) -> None:
             IssueSeverity.CRITICAL,
             OperatorIssueDetails(
                 "bdb",
-                "Bdb",
+                "Bdb.run",
                 IssueSeverity.CRITICAL,
                 f"{file_path}/data/malicious15.pkl",
             ),
@@ -1028,7 +1028,7 @@ def test_scan_pickle_operators(file_path: Any) -> None:
             IssueSeverity.CRITICAL,
             OperatorIssueDetails(
                 "bdb",
-                "Bdb.run",
+                "Bdb",
                 IssueSeverity.CRITICAL,
                 f"{file_path}/data/malicious15.pkl",
             ),

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -1302,6 +1302,26 @@ def test_scan_directory_path(file_path: str) -> None:
                 f"{file_path}/data/malicious14.pkl",
             ),
         ),
+        Issue(
+            IssueCode.UNSAFE_OPERATOR,
+            IssueSeverity.CRITICAL,
+            OperatorIssueDetails(
+                "bdb",
+                "Bdb",
+                IssueSeverity.CRITICAL,
+                f"{file_path}/data/malicious15.pkl",
+            ),
+        ),
+        Issue(
+            IssueCode.UNSAFE_OPERATOR,
+            IssueSeverity.CRITICAL,
+            OperatorIssueDetails(
+                "bdb",
+                "Bdb.run",
+                IssueSeverity.CRITICAL,
+                f"{file_path}/data/malicious15.pkl",
+            ),
+        ),
     }
     ms = ModelScan()
     p = Path(f"{file_path}/data/")
@@ -1320,6 +1340,7 @@ def test_scan_directory_path(file_path: str) -> None:
         "malicious12.pkl",
         "malicious13.pkl",
         "malicious14.pkl",
+        "malicious15.pkl",
         "malicious1_v0.dill",
         "malicious1_v3.dill",
         "malicious1_v4.dill",

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -1032,7 +1032,7 @@ def test_scan_pickle_operators(file_path: Any) -> None:
                 IssueSeverity.CRITICAL,
                 f"{file_path}/data/malicious15.pkl",
             ),
-        )
+        ),
     ]
     malicious15 = ModelScan()
     malicious15.scan(Path(f"{file_path}/data/malicious15.pkl"))


### PR DESCRIPTION
This is a port of https://github.com/mmaitre314/picklescan/pull/29 . We were notified that Python debuggers could run code, so adding those modules to the list of unsafe globals. Also adding shutil to flag file copies.