### PR TITLE
Fix: Detect "_pickle" imports

### DIFF
--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -125,6 +125,7 @@ DEFAULT_SETTINGS = {
             ],
             "pty": "*",
             "pickle": "*",
+            "_pickle": "*",
             "bdb": "*",
             "pdb": "*",
             "shutil": "*",


### PR DESCRIPTION
For Python 3, pickle automatically uses a C-optimized implementation called _pickle when available. Since only the pickle module is added to the unsafe globals, references to the C-optimized implementation of pickle are missed when scanning pickle files. This PR should fix that by adding _pickle to the unsafe globals.

Fixes #267 