### PR TITLE
fix: add dangerous TF ops to SavedModel unsafe_tf_operators blocklist

### DIFF
--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -50,6 +50,16 @@ DEFAULT_SETTINGS = {
             "unsafe_tf_operators": {
                 "ReadFile": "HIGH",
                 "WriteFile": "HIGH",
+                "MatchingFiles": "HIGH",
+                "WholeFileReader": "HIGH",
+                "WholeFileReaderV2": "HIGH",
+                "InitializeTableFromTextFile": "MEDIUM",
+                "InitializeTableFromTextFileV2": "MEDIUM",
+                "LMDBReader": "MEDIUM",
+                "PyFunc": "CRITICAL",
+                "PyFuncStateless": "CRITICAL",
+                "EagerPyFunc": "CRITICAL",
+                "FileSystemSetConfiguration": "MEDIUM",
             },
         },
         "modelscan.scanners.NumpyUnsafeOpScan": {

--- a/tests/test_savedmodel_dangerous_ops.py
+++ b/tests/test_savedmodel_dangerous_ops.py
@@ -1,0 +1,53 @@
+"""Test that modelscan detects dangerous TF ops beyond ReadFile/WriteFile.
+
+Verifies that filesystem enumeration (MatchingFiles), arbitrary Python
+execution (PyFunc/EagerPyFunc), and file reading ops (WholeFileReader)
+are flagged by the SavedModel scanner.
+"""
+
+import pytest
+
+
+class TestSavedModelDangerousOps:
+    """Test that unsafe_tf_operators blocklist catches dangerous ops."""
+
+    def test_matching_files_is_blocked(self):
+        from modelscan.settings import DEFAULT_SETTINGS
+        ops = DEFAULT_SETTINGS["scanners"][
+            "modelscan.scanners.SavedModelTensorflowOpScan"
+        ]["unsafe_tf_operators"]
+        assert "MatchingFiles" in ops
+        assert ops["MatchingFiles"] == "HIGH"
+
+    def test_pyfunc_is_blocked(self):
+        from modelscan.settings import DEFAULT_SETTINGS
+        ops = DEFAULT_SETTINGS["scanners"][
+            "modelscan.scanners.SavedModelTensorflowOpScan"
+        ]["unsafe_tf_operators"]
+        assert "PyFunc" in ops
+        assert ops["PyFunc"] == "CRITICAL"
+
+    def test_eager_pyfunc_is_blocked(self):
+        from modelscan.settings import DEFAULT_SETTINGS
+        ops = DEFAULT_SETTINGS["scanners"][
+            "modelscan.scanners.SavedModelTensorflowOpScan"
+        ]["unsafe_tf_operators"]
+        assert "EagerPyFunc" in ops
+        assert ops["EagerPyFunc"] == "CRITICAL"
+
+    def test_whole_file_reader_is_blocked(self):
+        from modelscan.settings import DEFAULT_SETTINGS
+        ops = DEFAULT_SETTINGS["scanners"][
+            "modelscan.scanners.SavedModelTensorflowOpScan"
+        ]["unsafe_tf_operators"]
+        assert "WholeFileReader" in ops
+        assert ops["WholeFileReader"] == "HIGH"
+
+    def test_original_ops_still_blocked(self):
+        """Ensure ReadFile and WriteFile are still present."""
+        from modelscan.settings import DEFAULT_SETTINGS
+        ops = DEFAULT_SETTINGS["scanners"][
+            "modelscan.scanners.SavedModelTensorflowOpScan"
+        ]["unsafe_tf_operators"]
+        assert "ReadFile" in ops
+        assert "WriteFile" in ops


### PR DESCRIPTION
## Summary

- Added 9 dangerous TensorFlow ops to the SavedModel scanner's `unsafe_tf_operators` blocklist
- Previously only `ReadFile` and `WriteFile` were blocked out of 1,462 raw_ops
- `MatchingFiles` enables filesystem enumeration that survives serialization and executes on `tf.saved_model.load()`

## Why

A SavedModel containing `tf.io.matching_files` (the `MatchingFiles` op) passes modelscan with 0 issues but enumerates the filesystem when loaded. The scanner actively scans the `.pb` file, encounters `MatchingFiles`, classifies it as a known safe op (since it's in `tf.raw_ops` but not in the 2-item blocklist), and reports no issues.

## Ops Added

| Op | Severity | Risk |
|----|----------|------|
| MatchingFiles | HIGH | Filesystem glob enumeration |
| WholeFileReader/V2 | HIGH | Reads entire files |
| InitializeTableFromTextFile/V2 | MEDIUM | File read via TF tables |
| LMDBReader | MEDIUM | Database read |
| PyFunc/PyFuncStateless/EagerPyFunc | CRITICAL | Arbitrary Python execution |
| FileSystemSetConfiguration | MEDIUM | Filesystem config modification |

## Testing

5 unit tests verifying each dangerous op category is present in the blocklist and original ops (ReadFile, WriteFile) are preserved.