### PR TITLE
Detect mailcap.findmatch pickle payloads

### DIFF
--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -130,6 +130,9 @@ DEFAULT_SETTINGS = {
             "pdb": "*",
             "shutil": "*",
             "asyncio": "*",
+            "mailcap": [
+                "findmatch",  # mailcap.findmatch executes matching entry test commands via os.system()
+            ],
         },
         "HIGH": {
             "webbrowser": "*",  # Includes webbrowser.open()

--- a/tests/test_pickle_unsafe_globals.py
+++ b/tests/test_pickle_unsafe_globals.py
@@ -1,0 +1,25 @@
+import pickle
+from typing import Any
+
+from modelscan.modelscan import ModelScan
+
+
+class MaliciousMailcapFindmatch:
+    def __reduce__(self) -> Any:
+        import mailcap
+
+        caps = {"text/plain": [{"view": "cat %s", "test": "true"}]}
+        return mailcap.findmatch, (caps, "text/plain")
+
+
+def test_scan_flags_mailcap_findmatch(tmp_path) -> None:
+    path = tmp_path / "mailcap.pkl"
+    path.write_bytes(pickle.dumps(MaliciousMailcapFindmatch()))
+
+    modelscan = ModelScan()
+    results = modelscan.scan(path)
+
+    assert results["summary"]["scanned"]["scanned_files"] == ["mailcap.pkl"]
+    assert results["summary"]["total_issues"] == 1
+    assert modelscan.issues.all_issues[0].details.module == "mailcap"
+    assert modelscan.issues.all_issues[0].details.operator == "findmatch"


### PR DESCRIPTION
## Summary
- add `mailcap.findmatch` to the unsafe pickle globals list
- cover the detection with a focused regression test that scans a pickle payload through `ModelScan`

## Why
`mailcap.findmatch` can execute a matching mailcap entry `test` command via `os.system()`. Without this entry, a pickle payload using that callable can scan cleanly even though unpickling can execute shell behavior.

## Testing
- `uv run --with-editable . --with pytest pytest tests/test_pickle_unsafe_globals.py`