### PR TITLE
Make NumPy an optional dependency

### DIFF
--- a/modelscan/scanners/pickle/scan.py
+++ b/modelscan/scanners/pickle/scan.py
@@ -1,9 +1,11 @@
 import logging
-from typing import Optional
+from typing import Any, Dict, Optional
 
+from modelscan.error import DependencyError
 from modelscan.scanners.scan import ScanBase, ScanResults
 from modelscan.tools.utils import _is_zipfile
 from modelscan.tools.picklescanner import (
+    numpy_installed,
     scan_numpy,
     scan_pickle_bytes,
     scan_pytorch,
@@ -53,6 +55,20 @@ class NumpyUnsafeOpScan(ScanBase):
         ]:
             return None
 
+        dep_error = self.handle_binary_dependencies()
+        if dep_error:
+            return ScanResults(
+                [],
+                [
+                    DependencyError(
+                        self.name(),
+                        f"To use {self.full_name()}, please install modelscan with numpy extras. `pip install 'modelscan[ numpy ]'` if you are using pip.",
+                        model,
+                    )
+                ],
+                [],
+            )
+
         results = scan_numpy(
             model=model,
             settings=self._settings,
@@ -67,6 +83,13 @@ class NumpyUnsafeOpScan(ScanBase):
     @staticmethod
     def full_name() -> str:
         return "modelscan.scanners.NumpyUnsafeOpScan"
+
+    def handle_binary_dependencies(
+        self, settings: Optional[Dict[str, Any]] = None
+    ) -> Optional[str]:
+        if not numpy_installed:
+            return DependencyError.name()
+        return None
 
 
 class PickleUnsafeOpScan(ScanBase):

--- a/modelscan/tools/picklescanner.py
+++ b/modelscan/tools/picklescanner.py
@@ -3,7 +3,13 @@ import pickletools  # nosec
 from tarfile import TarError
 from typing import IO, Any, Dict, List, Set, Tuple, Union, Optional
 
-import numpy as np
+try:
+    import numpy as np
+
+    numpy_installed = True
+except ImportError:
+    np = None  # type: ignore[assignment]
+    numpy_installed = False
 
 from modelscan.error import PickleGenopsError
 from modelscan.skip import ModelScanSkipped, SkipCategories
@@ -200,6 +206,9 @@ def _build_scan_result_from_raw_globals(
 
 
 def scan_numpy(model: Model, settings: Dict[str, Any]) -> ScanResults:
+    if np is None:
+        raise ImportError("NumPy is required to scan NumPy model files.")
+
     scan_name = "numpy"
     # Code to distinguish from NumPy binary files and pickles.
     _ZIP_PREFIX = b"PK\x03\x04"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1337,6 +1337,7 @@ files = [
     {file = "numpy-2.0.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:a46288ec55ebbd58947d31d72be2c63cbf839f0a63b49cb755022310792a3385"},
     {file = "numpy-2.0.2.tar.gz", hash = "sha256:883c987dee1880e2a864ab0dc9892292582510604156762362d9326444636e78"},
 ]
+markers = {main = "extra == \"tensorflow\" or extra == \"numpy\" or extra == \"h5py\""}
 
 [[package]]
 name = "nvidia-cublas-cu12"
@@ -2746,9 +2747,10 @@ propcache = ">=0.2.0"
 
 [extras]
 h5py = ["h5py"]
+numpy = ["numpy"]
 tensorflow = ["tensorflow"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<3.13"
-content-hash = "2f09c0bcd97aa87a4ff5cb2e72d4b26c2c5297eaac4828f838e7313f3a09f4a7"
+content-hash = "8c6ebc8344e69b0c3e8e298cbf8abdb6c8884283ae13fcf69f04e545115e2928"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ modelscan = "modelscan.cli:main"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 click = "^8.1.3"
-numpy = ">=1.24.3"
+numpy = { version = ">=1.24.3", optional = true }
 rich = ">=13.4.2,<15.0.0"
 tomlkit = ">=0.12.3,<0.14.0"
 h5py = { version = "^3.9.0", optional = true }
@@ -25,6 +25,7 @@ tensorflow = { version = "^2.17", optional = true }
 [tool.poetry.extras]
 tensorflow = ["tensorflow"]
 h5py = ["h5py"]
+numpy = ["numpy"]
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.4,<9.0"
@@ -36,6 +37,7 @@ dill = ">=0.3.7,<0.5.0"
 types-requests = ">1.26"
 torch = "^2.7.0"
 tf-keras = "^2.20.1"
+numpy = ">=1.24.3"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -39,7 +39,7 @@ from modelscan.tools.picklescanner import (
 )
 
 from modelscan.skip import SkipCategories
-from modelscan.settings import DEFAULT_SETTINGS
+from modelscan.settings import DEFAULT_SETTINGS, SupportedModelFormats
 from modelscan.model import Model
 
 settings: Dict[str, Any] = DEFAULT_SETTINGS
@@ -604,6 +604,24 @@ def test_scan_numpy(numpy_file_path: Any) -> None:
     assert results["summary"]["scanned"]["scanned_files"] == ["unsafe_numpy.npy"]
     assert results["summary"]["skipped"]["skipped_files"] == []
     assert results["errors"] == []
+
+
+def test_scan_numpy_reports_dependency_error_when_numpy_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from modelscan.scanners.pickle import scan as pickle_scan
+
+    monkeypatch.setattr(pickle_scan, "numpy_installed", False)
+
+    model = Model("missing_numpy.npy", io.BytesIO(b""))
+    model.set_context("formats", [SupportedModelFormats.NUMPY])
+    scanner = pickle_scan.NumpyUnsafeOpScan(settings)
+
+    results = scanner.scan(model)
+
+    assert results is not None
+    assert [error.to_dict()["category"] for error in results.errors] == ["DEPENDENCY"]
+    assert "modelscan[ numpy ]" in results.errors[0].message
 
 
 def test_scan_file_path(file_path: Any) -> None:


### PR DESCRIPTION
## Summary
- move NumPy from the core dependencies into a `numpy` extra
- keep pickle and PyTorch scanning importable without NumPy installed
- return a dependency error for NumPy scans when the extra is missing

Fixes #79

## Tests
- uvx poetry run pytest tests/test_modelscan.py -k numpy
- uvx poetry run mypy modelscan/scanners/pickle/scan.py modelscan/tools/picklescanner.py
- uvx poetry run black --check modelscan/scanners/pickle/scan.py modelscan/tools/picklescanner.py tests/test_modelscan.py