### PR TITLE
Fix fail-open ZIP iteration in _iterate_models (BadZipFile bypass)

### DIFF
--- a/modelscan/modelscan.py
+++ b/modelscan/modelscan.py
@@ -98,18 +98,39 @@ class ModelScan:
                     with zipfile.ZipFile(model.get_stream(), "r") as zip:
                         file_names = zip.namelist()
                         for file_name in file_names:
-                            with zip.open(file_name, "r") as file_io:
-                                file_name = f"{model.get_source()}:{file_name}"
-                                if _is_zipfile(file_name, data=file_io):
-                                    self._errors.append(
-                                        NestedZipError(
-                                            "ModelScan does not support nested zip files.",
-                                            Path(file_name),
+                            entry_source = f"{model.get_source()}:{file_name}"
+                            # Handle each entry individually. A single unreadable
+                            # entry (e.g. a corrupted local file header that raises
+                            # BadZipFile on open) must not abort enumeration of the
+                            # remaining entries -- otherwise a crafted archive could
+                            # hide a malicious entry behind a corrupted one and have
+                            # modelscan report the whole archive as clean.
+                            try:
+                                with zip.open(file_name, "r") as file_io:
+                                    if _is_zipfile(entry_source, data=file_io):
+                                        self._errors.append(
+                                            NestedZipError(
+                                                "ModelScan does not support nested zip files.",
+                                                Path(entry_source),
+                                            )
                                         )
-                                    )
-                                    continue
+                                        continue
 
-                                yield Model(file_name, file_io)
+                                    yield Model(entry_source, file_io)
+                            except (zipfile.BadZipFile, RuntimeError) as e:
+                                logger.debug(
+                                    "Skipping zip entry %s, due to error",
+                                    entry_source,
+                                    exc_info=True,
+                                )
+                                self._skipped.append(
+                                    ModelScanSkipped(
+                                        "ModelScan",
+                                        SkipCategories.BAD_ZIP,
+                                        f"Skipping zip entry due to error: {e}",
+                                        entry_source,
+                                    )
+                                )
                 except (zipfile.BadZipFile, RuntimeError) as e:
                     logger.debug(
                         "Skipping zip file %s, due to error",


### PR DESCRIPTION
_iterate_models() wrapped the entire inner-ZIP entry loop in a single `except (zipfile.BadZipFile, RuntimeError)`. If any one entry raised BadZipFile on `zip.open()` (e.g. a corrupted local file header), the exception aborted enumeration of the whole archive: every entry after the bad one was silently dropped and never scanned.

A crafted archive can exploit this by placing a corrupted entry before `archive/data.pkl` in the namelist. modelscan aborts on the corrupted entry and reports 0 issues (CLEAN), while a consumer (`torch.load` / `pickle.load`) reads `archive/data.pkl` directly by name from the intact central directory and executes the malicious pickle -> RCE.

Move the per-entry handling into its own try/except so a single unreadable entry is recorded as skipped (with its source) and iteration continues to the remaining entries. The outer handler is kept for an archive whose central directory itself is unreadable.

Fixes #354