### PR TITLE
Add transformers.dynamic_module_utils to CRITICAL unsafe_globals blocklist

### DIFF
--- a/modelscan/settings.py
+++ b/modelscan/settings.py
@@ -130,6 +130,7 @@ DEFAULT_SETTINGS = {
             "pdb": "*",
             "shutil": "*",
             "asyncio": "*",
+            "transformers.dynamic_module_utils": "*",  # Downloads and executes arbitrary Python from HuggingFace Hub or local path at unpickle time; callable directly from a pickle gadget without trust_remote_code consent gate
         },
         "HIGH": {
             "webbrowser": "*",  # Includes webbrowser.open()

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -145,6 +145,39 @@ def malicious13_gen() -> bytes:
     return p
 
 
+def malicious_transformers_gen_v2() -> bytes:
+    # Protocol 2, GLOBAL opcode path (pickle v0-v3 scanner branch).
+    # transformers.dynamic_module_utils was absent from unsafe_globals, so
+    # this gadget passed ModelScan with 0 issues before the fix.
+    return (
+        pickle.PROTO + b"\x02"
+        + pickle.GLOBAL
+        + b"transformers.dynamic_module_utils\nget_class_from_dynamic_module\n"
+        + pickle.MARK
+        + pickle.TUPLE
+        + pickle.REDUCE
+        + pickle.STOP
+    )
+
+
+def malicious_transformers_gen_v4() -> bytes:
+    # Protocol 4, STACK_GLOBAL opcode path (pickle v4 scanner branch).
+    mod = b"transformers.dynamic_module_utils"
+    name = b"get_class_from_dynamic_module"
+    # frame payload: SHORT_BINUNICODE(mod) + SHORT_BINUNICODE(name) + STACK_GLOBAL + MARK + TUPLE + REDUCE + STOP
+    frame_len = (1 + 1 + len(mod)) + (1 + 1 + len(name)) + 5
+    p = pickle.PROTO + b"\x04"
+    p += pickle.FRAME + frame_len.to_bytes(8, "little")
+    p += pickle.SHORT_BINUNICODE + bytes([len(mod)]) + mod
+    p += pickle.SHORT_BINUNICODE + bytes([len(name)]) + name
+    p += pickle.STACK_GLOBAL
+    p += pickle.MARK
+    p += pickle.TUPLE
+    p += pickle.REDUCE
+    p += pickle.STOP
+    return p
+
+
 def malicious14_gen() -> bytes:
     p = b"".join(
         [
@@ -331,6 +364,13 @@ def file_path(tmp_path_factory: Any) -> Any:
 
     initialize_data_file(f"{tmp}/data/malicious14.pkl", malicious14_gen())
 
+    initialize_data_file(
+        f"{tmp}/data/malicious_transformers_v2.pkl", malicious_transformers_gen_v2()
+    )
+    initialize_data_file(
+        f"{tmp}/data/malicious_transformers_v4.pkl", malicious_transformers_gen_v4()
+    )
+
     shutil.copy(
         f"{os.path.dirname(__file__)}/data/password_protected.zip", f"{tmp}/data/"
     )
@@ -483,6 +523,27 @@ def test_scan_pickle_bytes() -> None:
 
     model = Model("file.pkl", io.BytesIO(pickle.dumps(Malicious1())))
     assert scan_pickle_bytes(model, settings).issues == expected
+
+
+@pytest.mark.parametrize(
+    "pkl_bytes,filename",
+    [
+        (malicious_transformers_gen_v2(), "malicious_transformers_v2.pkl"),
+        (malicious_transformers_gen_v4(), "malicious_transformers_v4.pkl"),
+    ],
+)
+def test_scan_pickle_transformers_gadget(pkl_bytes: bytes, filename: str) -> None:
+    # transformers.dynamic_module_utils.get_class_from_dynamic_module downloads
+    # and executes arbitrary Python from HuggingFace Hub (or local path) at
+    # unpickle time without a trust_remote_code consent gate. Both the GLOBAL
+    # opcode (v2) and STACK_GLOBAL opcode (v4) paths must be flagged CRITICAL.
+    model = Model(filename, io.BytesIO(pkl_bytes))
+    issues = scan_pickle_bytes(model, settings).issues
+    assert len(issues) == 1, f"expected 1 CRITICAL issue, got {issues}"
+    assert issues[0].code == IssueCode.UNSAFE_OPERATOR
+    assert issues[0].severity == IssueSeverity.CRITICAL
+    assert issues[0].details.module == "transformers.dynamic_module_utils"
+    assert issues[0].details.operator == "get_class_from_dynamic_module"
 
 
 def test_scan_zip(zip_file_path: Any) -> None:


### PR DESCRIPTION
## Summary

`transformers.dynamic_module_utils.get_class_from_dynamic_module` downloads and executes arbitrary Python from a HuggingFace Hub repository (or a local path) at unpickle time. Because no `transformers.*` symbol appeared in the `unsafe_globals` blocklist, a pickle gadget using either the GLOBAL opcode (protocol v2) or the STACK_GLOBAL opcode (protocol v4) passed ModelScan with **0 issues** while achieving full RCE on `joblib.load`, `pickle.load`, and `torch.load(weights_only=False)`.

Disclosed in huntr report [ac7bd4e9](https://huntr.com/bounties/ac7bd4e9-3b8b-41e3-bc8b-b1b19b2427d4) (validated, fix bounty open).

## Changes

- `modelscan/settings.py`: adds `"transformers.dynamic_module_utils": "*"` to the `CRITICAL` tier. Wildcard covers `get_class_from_dynamic_module` and all other callables in the module that share the same download-and-execute behavior.
- `tests/test_modelscan.py`: adds `malicious_transformers_gen_v2()` (GLOBAL opcode, protocol 2) and `malicious_transformers_gen_v4()` (STACK_GLOBAL opcode, protocol 4) generators, a parametrized fixture initialization for both, and `test_scan_pickle_transformers_gadget` asserting both are detected as `CRITICAL` with the correct module and operator fields. No transformers package import required in the test suite.

## Why CRITICAL (not HIGH)

The function's own docstring says "It should therefore only be called on trusted repos." When invoked from a pickle gadget it bypasses the `trust_remote_code` consent gate entirely, making it equivalent in impact to `os.system` / `subprocess.run`.

## Test

```
pytest tests/test_modelscan.py::test_scan_pickle_transformers_gadget -v
```

Expected: 2 parametrized cases, each producing 1 CRITICAL issue with `module=transformers.dynamic_module_utils`, `operator=get_class_from_dynamic_module`.