### PR TITLE
fix(cli): stop leaking a file handle in create-settings-file

### DIFF
--- a/modelscan/cli.py
+++ b/modelscan/cli.py
@@ -173,22 +173,15 @@ def create_settings(force: bool, location: Optional[str]) -> None:
     if location:
         settings_path = location
 
-    try:
-        open(settings_path, encoding="utf-8")
-        if force:
-            with open(settings_path, mode="w", encoding="utf-8") as settings_file:
-                settings_file.write(SettingsUtils.get_default_settings_as_toml())
-                settings_file.close()
-        else:
-            logger.warning(
-                "%s file already exists. Please use `--force` flag if you intend to overwrite it.",
-                settings_path,
-            )
+    if os.path.exists(settings_path) and not force:
+        logger.warning(
+            "%s file already exists. Please use `--force` flag if you intend to overwrite it.",
+            settings_path,
+        )
+        return
 
-    except FileNotFoundError:
-        with open(settings_path, mode="w", encoding="utf-8") as settings_file:
-            settings_file.write(SettingsUtils.get_default_settings_as_toml())
-            settings_file.close()
+    with open(settings_path, mode="w", encoding="utf-8") as settings_file:
+        settings_file.write(SettingsUtils.get_default_settings_as_toml())
 
 
 def main() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+# Tests for the modelscan command line interface.
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from modelscan.cli import create_settings
+
+
+def test_create_settings_keeps_an_existing_file(tmp_path: Path) -> None:
+    """Without --force an existing settings file is left untouched."""
+    settings_path = tmp_path / "modelscan-settings.toml"
+    settings_path.write_text("# custom settings\n", encoding="utf-8")
+
+    result = CliRunner().invoke(create_settings, ["--location", str(settings_path)])
+
+    assert result.exit_code == 0
+    assert settings_path.read_text(encoding="utf-8") == "# custom settings\n"


### PR DESCRIPTION
Fixes #226

`create_settings` used `open()` as an existence check and never closed the handle — that is the CodeQL
finding at `cli.py:177`:

```python
try:
    open(settings_path, encoding="utf-8")
    if force:
        ...
except FileNotFoundError:
    ...
```

Replaced with an explicit `os.path.exists()` check, so no handle is opened for the check at all, and the
write path exists once instead of twice. Behaviour is unchanged: without `--force` an existing file is kept
and the warning is logged; with `--force`, or when the file does not exist, the default settings are written.
The redundant `settings_file.close()` calls inside the `with` blocks went away with the duplication.

### Test

`tests/test_cli.py` (new): invoking the command against an existing file without `--force` leaves the file
untouched — this is the branch the fix rewrote.

```
PYTHONPATH=/src python -m pytest tests/test_cli.py -q   ->  1 passed
```

### One thing I could not cover, and why

I wanted to also assert that the file *is* written when it does not exist, but that path is currently broken
on `main`, independently of this PR:

```
$ python -c "from modelscan.settings import SettingsUtils; SettingsUtils.get_default_settings_as_toml()"
TypeError: Keys must be strings
```

`DEFAULT_SETTINGS["middlewares"]["modelscan.middlewares.FormatViaExtensionMiddleware"]["formats"]` is keyed by
`SupportedModelFormats.*`, which are `Property` instances, and `tomlkit.dumps()` only accepts string keys — so
`modelscan create-settings-file` fails for everyone right now (tomlkit 0.13, within the `>=0.12.3,<0.14.0` pin).
That is a separate bug from this one; happy to open an issue for it, or send a fix if you tell me which shape
you prefer — string keys in `DEFAULT_SETTINGS`, or a conversion at serialisation time so the in-memory lookups
keep working.

AI-assisted (LLM used for drafting); the change, the test run and the reproduction above are mine.
