### PR TITLE
fix(reports): do not report success when every model was skipped

### DIFF
--- a/modelscan/reports.py
+++ b/modelscan/reports.py
@@ -60,6 +60,12 @@ class ConsoleReport(Report):
                 print(f"\n[blue]--- {issue_keys} ---")
                 for issue in issues_by_severity[issue_keys]:
                     issue.print()
+        elif scan.skipped:
+            # Nothing was scanned successfully, so "no issues" would be misleading.
+            print(
+                "\n[yellow] No issues found in the scanned files, but "
+                f"{len(scan.skipped)} file(s) were skipped and not scanned."
+            )
         else:
             print("\n[green] No issues found! 🎉")
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,0 +1,36 @@
+# Tests for the modelscan console report.
+from typing import Any, Dict, List
+
+from modelscan.reports import ConsoleReport
+
+
+class _Issues:
+    def __init__(self) -> None:
+        self.all_issues: List[Any] = []
+
+    def group_by_severity(self) -> Dict[str, Any]:
+        return {}
+
+
+class _Scan:
+    """Minimal stand-in for ModelScan: no issues, no errors, N skipped files."""
+
+    def __init__(self, skipped: List[str]) -> None:
+        self.issues = _Issues()
+        self.errors: List[Any] = []
+        self.skipped = skipped
+
+
+def test_console_report_does_not_claim_success_when_files_are_skipped(capsys: Any) -> None:
+    ConsoleReport.generate(_Scan(["model.bin"]), settings={"show_skipped": False})
+
+    output = capsys.readouterr().out
+    assert "No issues found!" not in output
+    assert "No issues found in the scanned files" in output
+    assert "1 file(s) were skipped" in output
+
+
+def test_console_report_reports_success_when_nothing_is_skipped(capsys: Any) -> None:
+    ConsoleReport.generate(_Scan([]), settings={"show_skipped": False})
+
+    assert "No issues found!" in capsys.readouterr().out


### PR DESCRIPTION
Fixes #218

When every model in the scan was skipped, the console report still printed the success line:

```
--- Summary ---

 No issues found! 🎉

--- Skipped ---

Total skipped: 1 - run with --show-skipped to see the full list.
```

"No issues found" is only true of files that were actually scanned, and the skip notice sits below the
line most people stop reading at.

`ConsoleReport` now distinguishes the two cases:

```
 No issues found in the scanned files, but 1 file(s) were skipped and not scanned.
```

The cheerful line stays exactly as it was when nothing was skipped, so a clean scan looks the same as before.
Exit codes are untouched — this PR only changes what the summary says.

### Tests

`tests/test_reports.py` (new): with a skipped file the output must not contain "No issues found!" and must
mention the skipped count; with nothing skipped the original line must still appear.

```
PYTHONPATH=/src python -m pytest tests/test_reports.py tests/test_cli.py -q   ->  3 passed
```

AI-assisted (LLM used for drafting); the change and the test run are mine.
