### PR TITLE
Add metadata field to scan reports

### DIFF
--- a/modelscan/reports.py
+++ b/modelscan/reports.py
@@ -1,12 +1,14 @@
 import abc
 import logging
 import json
+from datetime import datetime
 from typing import Optional, Dict, Any
 
 from rich import print
 
 from modelscan.modelscan import ModelScan
 from modelscan.issues import IssueSeverity
+from modelscan._version import __version__
 
 logger = logging.getLogger("modelscan")
 
@@ -34,6 +36,32 @@ class Report(metaclass=abc.ABCMeta):
         """
         raise NotImplementedError
 
+    @staticmethod
+    def build_metadata(
+        scan: ModelScan,
+        settings: Dict[str, Any] = {},
+    ) -> Dict[str, Any]:
+        """
+        Assemble the report metadata block.
+
+        Seeds a few run-level fields that are available at report time, then
+        layers any caller-supplied metadata (settings["metadata"]) on top so a
+        scanner or embedding tool can attach arbitrary info (file dates, what
+        data was scanned, etc.). Caller keys win on conflict.
+        """
+        metadata: Dict[str, Any] = {
+            "modelscan_version": __version__,
+            "timestamp": datetime.now().isoformat(),
+            "input_path": str(scan._input_path),
+            "total_scanned": len(scan.scanned),
+        }
+
+        extra = settings.get("metadata")
+        if extra:
+            metadata.update(extra)
+
+        return metadata
+
 
 class ConsoleReport(Report):
     @staticmethod
@@ -41,6 +69,11 @@ class ConsoleReport(Report):
         scan: ModelScan,
         settings: Dict[str, Any] = {},
     ) -> None:
+        metadata = Report.build_metadata(scan, settings)
+        print("\n[blue]--- Metadata ---")
+        for key, value in metadata.items():
+            print(f"\n{key}: {value}")
+
         issues_by_severity = scan.issues.group_by_severity()
         print("\n[blue]--- Summary ---")
         total_issue_count = len(scan.issues.all_issues)
@@ -87,6 +120,7 @@ class JSONReport(Report):
         settings: Dict[str, Any] = {},
     ) -> None:
         report: Dict[str, Any] = scan._generate_results()
+        report["metadata"] = Report.build_metadata(scan, settings)
         if not settings.get("show_skipped"):
             del report["summary"]["skipped"]
 

--- a/tests/test_modelscan.py
+++ b/tests/test_modelscan.py
@@ -41,6 +41,8 @@ from modelscan.tools.picklescanner import (
 from modelscan.skip import SkipCategories
 from modelscan.settings import DEFAULT_SETTINGS
 from modelscan.model import Model
+from modelscan.reports import Report, JSONReport
+from modelscan._version import __version__
 
 settings: Dict[str, Any] = DEFAULT_SETTINGS
 
@@ -1644,3 +1646,54 @@ def test_main_defaultgroup(file_path: Any) -> None:
         pass
     finally:
         sys.argv = argv
+
+
+def test_report_metadata(file_path: Any, tmp_path: Any) -> None:
+    ms = ModelScan()
+    ms.scan(Path(f"{file_path}/data/benign0_v3.pkl"))
+
+    metadata = Report.build_metadata(ms, settings={})
+    assert set(metadata.keys()) >= {
+        "modelscan_version",
+        "timestamp",
+        "input_path",
+        "total_scanned",
+    }
+    assert metadata["modelscan_version"] == __version__
+    assert metadata["input_path"] == str(Path(f"{file_path}/data/benign0_v3.pkl"))
+    assert metadata["total_scanned"] == len(ms.scanned)
+
+    # Caller-supplied metadata is merged in and wins on conflict.
+    merged = Report.build_metadata(
+        ms,
+        settings={"metadata": {"data_scanned": "hf://acme/model", "total_scanned": 99}},
+    )
+    assert merged["data_scanned"] == "hf://acme/model"
+    assert merged["total_scanned"] == 99
+
+
+def test_json_report_includes_metadata(file_path: Any, tmp_path: Any) -> None:
+    ms = ModelScan()
+    ms.scan(Path(f"{file_path}/data/benign0_v3.pkl"))
+
+    output_file = f"{tmp_path}/report.json"
+    JSONReport.generate(
+        ms,
+        settings={
+            "output_file": output_file,
+            "metadata": {"data_scanned": "local pickle"},
+        },
+    )
+
+    with open(output_file) as f:
+        report = json.load(f)
+
+    assert "metadata" in report
+    assert report["metadata"]["modelscan_version"] == __version__
+    assert report["metadata"]["input_path"] == str(
+        Path(f"{file_path}/data/benign0_v3.pkl")
+    )
+    assert report["metadata"]["data_scanned"] == "local pickle"
+    # Existing top-level structure stays intact.
+    assert "summary" in report
+    assert "issues" in report


### PR DESCRIPTION
Closes #59. Adds a generic `metadata` block to scan reports so a scanner or an embedding tool can attach arbitrary info about a run (file dates, what data was scanned, that kind of thing).

There's a new `Report.build_metadata` helper on the base class. It seeds a few run-level fields that are already on hand at report time (`modelscan_version`, `timestamp`, `input_path`, `total_scanned`) and then merges whatever the caller passes in `settings["metadata"]`, with caller keys winning on conflict. `JSONReport` surfaces it as a top-level `metadata` key and `ConsoleReport` prints a short `--- Metadata ---` section. Everything else in the output is left alone, so anything already parsing the current JSON keeps working.

Callers set custom fields through the reporting settings:

```python
modelscan._settings["reporting"]["settings"]["metadata"] = {"data_scanned": "hf://acme/model"}
```

The issue leaves the exact field set open, so I went with the obvious run-level ones. A couple of them overlap what's already in `summary`. That's deliberate so `metadata` reads as one self-contained blob, but I'm happy to drop the overlap if you'd rather keep this purely for scanner-supplied data.

Added tests in `tests/test_modelscan.py` covering the seeded keys, the caller merge/override, and that the JSON report carries `metadata` while `summary`/`issues` stay intact. black and mypy (strict) are clean on the change.
