### PR TITLE
build: make NumPy an optional dependency

### DIFF
--- a/modelscan/tools/picklescanner.py
+++ b/modelscan/tools/picklescanner.py
@@ -3,8 +3,6 @@ import pickletools  # nosec
 from tarfile import TarError
 from typing import IO, Any, Dict, List, Set, Tuple, Union, Optional
 
-import numpy as np
-
 from modelscan.error import PickleGenopsError
 from modelscan.skip import ModelScanSkipped, SkipCategories
 from modelscan.issues import Issue, IssueCode, IssueSeverity, OperatorIssueDetails
@@ -201,6 +199,16 @@ def _build_scan_result_from_raw_globals(
 
 def scan_numpy(model: Model, settings: Dict[str, Any]) -> ScanResults:
     scan_name = "numpy"
+    # NumPy is an optional dependency (only needed for .npy scanning);
+    # import lazily so the package works without it installed.
+    try:
+        import numpy as np  # noqa: F401 - used below for extension checks
+    except ImportError as exc:
+        raise ModelScanSkipped(
+            model,
+            SkipCategories.UNSUPPORTED,
+            "numpy is not installed; skipping NumPy file scanning",
+        ) from exc
     # Code to distinguish from NumPy binary files and pickles.
     _ZIP_PREFIX = b"PK\x03\x04"
     _ZIP_SUFFIX = b"PK\x05\x06"  # empty zip files start with this

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ modelscan = "modelscan.cli:main"
 [tool.poetry.dependencies]
 python = ">=3.10,<3.13"
 click = "^8.1.3"
-numpy = ">=1.24.3"
+numpy = { version = ">=1.24.3", optional = true }
 rich = ">=13.4.2,<15.0.0"
 tomlkit = ">=0.12.3,<0.14.0"
 h5py = { version = "^3.9.0", optional = true }
@@ -25,6 +25,7 @@ tensorflow = { version = "^2.17", optional = true }
 [tool.poetry.extras]
 tensorflow = ["tensorflow"]
 h5py = ["h5py"]
+numpy = ["numpy"]
 
 [tool.poetry.group.test.dependencies]
 pytest = ">=7.4,<9.0"


### PR DESCRIPTION
## Summary

NumPy is only required when scanning `.npy` files. Following the same pattern already used for TensorFlow, this PR makes NumPy an optional dependency so users are not forced to install a heavy dependency they don't plan to use.

## Changes

- `pyproject.toml`: `numpy` moved to `optional = true`, added `numpy = ["numpy"]` extra
- `modelscan/tools/picklescanner.py`: removed top-level `import numpy as np`; `scan_numpy()` now imports NumPy lazily and raises `ModelScanSkipped` (category `UNSUPPORTED`) with a clear message when NumPy is not installed

## Acceptance criteria

- [x] NumPy is optional (not required for base install)
- [x] Package imports fine without NumPy
- [x] `.npy` scanning still works when NumPy is installed
- [x] Clear message when NumPy missing during `.npy` scanning